### PR TITLE
Change styling a bit

### DIFF
--- a/nav.js
+++ b/nav.js
@@ -56,3 +56,8 @@ for (i = 0; i < coll.length; i++) {
 
 getExpandedCookie();
 expandExpanded();
+
+for (const collapsible of document.getElementsByClassName('collapsible')) {
+    collapsible.addEventListener('click', () =>
+        collapsible.classList.remove('collapsed'));
+}

--- a/nav.js
+++ b/nav.js
@@ -57,7 +57,7 @@ for (i = 0; i < coll.length; i++) {
 getExpandedCookie();
 expandExpanded();
 
-for (const collapsible of document.getElementsByClassName('collapsible')) {
-    collapsible.addEventListener('click', () =>
-        collapsible.classList.remove('collapsed'));
+for (const impl_collapsed of document.getElementsByClassName('impl_collapsed')) {
+    impl_collapsed.getElementsByClassName('impl_arg')[0].addEventListener('click', () =>
+        impl_collapsed.classList.remove('impl_collapsed'));
 }

--- a/print_docs.py
+++ b/print_docs.py
@@ -138,7 +138,7 @@ def write_decl_html(obj, loc_map, instances, out):
   cstrs = '<li class="structure_fields">\nConstructors:\n<ul>{}\n</ul></li>'.format('\n'.join(cstr)) if len(cstr) > 0 else ''
   kind = 'structure' if len(sf) > 0 else 'inductive' if len(cstrs) > 0 else obj['kind']
   name = '<a href="{0}">{1}</a>'.format(library_link(obj['filename'], obj['line']), obj['name'])
-  attr_string = '<li>Attributes: ' + ', '.join(obj['attributes']) + '</li>' if len(obj['attributes']) > 0 else ''
+  attr_string = '<div class="attributes">@[' + ', '.join(obj['attributes']) + ']</div>' if len(obj['attributes']) > 0 else ''
   impls = [linkify_type(s['arg'], loc_map) for s in obj['args'] if s['implicit']]
   impls = ['<span class="decl_args impl_arg">{}</span>'.format(s) for s in impls]
   impl_string = '<span class="collapsible collapsed impl_args">{}</span>'.format(' '.join(impls)) if len(impls) > 0 else ''
@@ -149,10 +149,10 @@ def write_decl_html(obj, loc_map, instances, out):
   else:
     inst_string = ''
   out.write(
-    '<div class="{4}"><a id="{0}"></a>\
+    '<div class="{4}" id="{0}">{3} \
       <div class="decl_header"><span class="decl_name">{6}</span> {9} {5} <span class="decl_args">:</span> \
       <div class="decl_type">{1}</div></div>\n{2} \
-      <ul>\n{3}\n{7}\n{8}\n{10}\n</ul></div>'.format(
+      <ul>\n{7}\n{8}\n{10}\n</ul></div>'.format(
       obj['name'], type, doc_string, attr_string, kind, args, name, sfs, cstrs, impl_string, inst_string)
   )
 

--- a/print_docs.py
+++ b/print_docs.py
@@ -150,8 +150,8 @@ def write_decl_html(obj, loc_map, instances, out):
     inst_string = ''
   out.write(
     '<div class="{4}"><a id="{0}"></a>\
-      <span class="decl_name">{6}</span> {5} <span class="decl_args">:</span> \
-      <div class="decl_type">{1}</div>\n{2} \
+      <div class="decl_header"><span class="decl_name">{6}</span> {5} <span class="decl_args">:</span> \
+      <div class="decl_type">{1}</div></div>\n{2} \
       <ul>\n{9}\n{3}\n{7}\n{8}\n{10}\n</ul></div>'.format(
       obj['name'], type, doc_string, attr_string, kind, args, name, sfs, cstrs, impl_string, inst_string)
   )

--- a/print_docs.py
+++ b/print_docs.py
@@ -129,8 +129,13 @@ def linkify_markdown(string, loc_map):
 def write_decl_html(obj, loc_map, instances, out):
   doc_string = markdown2.markdown(obj['doc_string'], extras=["code-friendly", 'cuddled-lists', 'fenced-code-blocks'])
   type = linkify_type(obj['type'], loc_map)
-  args = [linkify_type(s['arg'], loc_map) for s in obj['args'] if not s['implicit']]
-  args = ['<span class="decl_args">{}</span>'.format(s) for s in args]
+  args = []
+  for s in obj['args']:
+    clss = ['decl_args']
+    clss = ' '.join(clss)
+    arg = '<span class="decl_args">{}</span>'.format(linkify_type(s['arg'], loc_map), clss)
+    if s['implicit']: arg = '<span class="impl_arg">{}</span>'.format(arg)
+    args.append(arg)
   args = ' '.join(args)
   sf = ['<li><div class="structure_field">{0} : {1}</div></li>'.format(name, linkify_type(tp, loc_map)) for (name, tp) in obj['structure_fields']]
   sfs = '<li class="structure_fields">\nFields:\n<ul>{}\n</ul></li>'.format('\n'.join(sf)) if len(sf) > 0 else ''
@@ -139,9 +144,6 @@ def write_decl_html(obj, loc_map, instances, out):
   kind = 'structure' if len(sf) > 0 else 'inductive' if len(cstrs) > 0 else obj['kind']
   name = '<a href="{0}">{1}</a>'.format(library_link(obj['filename'], obj['line']), obj['name'])
   attr_string = '<div class="attributes">@[' + ', '.join(obj['attributes']) + ']</div>' if len(obj['attributes']) > 0 else ''
-  impls = [linkify_type(s['arg'], loc_map) for s in obj['args'] if s['implicit']]
-  impls = ['<span class="decl_args impl_arg">{}</span>'.format(s) for s in impls]
-  impl_string = '<span class="collapsible collapsed impl_args">{}</span>'.format(' '.join(impls)) if len(impls) > 0 else ''
   if obj['name'] in instances:
     insts = instances[obj['name']]
     insts = ['<li class="structure_field">{}</li>'.format(linkify_type(n, loc_map)) for n in insts]
@@ -150,10 +152,10 @@ def write_decl_html(obj, loc_map, instances, out):
     inst_string = ''
   out.write(
     '<div class="{4}" id="{0}">{3} \
-      <div class="decl_header"><span class="decl_name">{6}</span> {9} {5} <span class="decl_args">:</span> \
+      <div class="decl_header impl_collapsed"><span class="decl_name">{6}</span> {5} <span class="decl_args">:</span> \
       <div class="decl_type">{1}</div></div>\n{2} \
-      <ul>\n{7}\n{8}\n{10}\n</ul></div>'.format(
-      obj['name'], type, doc_string, attr_string, kind, args, name, sfs, cstrs, impl_string, inst_string)
+      <ul>\n{7}\n{8}\n{9}\n</ul></div>'.format(
+      obj['name'], type, doc_string, attr_string, kind, args, name, sfs, cstrs, inst_string)
   )
 
 search_snippet = """

--- a/print_docs.py
+++ b/print_docs.py
@@ -140,8 +140,8 @@ def write_decl_html(obj, loc_map, instances, out):
   name = '<a href="{0}">{1}</a>'.format(library_link(obj['filename'], obj['line']), obj['name'])
   attr_string = '<li>Attributes: ' + ', '.join(obj['attributes']) + '</li>' if len(obj['attributes']) > 0 else ''
   impls = [linkify_type(s['arg'], loc_map) for s in obj['args'] if s['implicit']]
-  impls = ['<span class="impl_arg">{}</span>'.format(s) for s in impls]
-  impl_string = '<li>Implicit arguments: {}</li>'.format(' '.join(impls)) if len(impls) > 0 else ''
+  impls = ['<span class="decl_args impl_arg">{}</span>'.format(s) for s in impls]
+  impl_string = '<span class="collapsible collapsed impl_args">{}</span>'.format(' '.join(impls)) if len(impls) > 0 else ''
   if obj['name'] in instances:
     insts = instances[obj['name']]
     insts = ['<li class="structure_field">{}</li>'.format(linkify_type(n, loc_map)) for n in insts]
@@ -150,9 +150,9 @@ def write_decl_html(obj, loc_map, instances, out):
     inst_string = ''
   out.write(
     '<div class="{4}"><a id="{0}"></a>\
-      <div class="decl_header"><span class="decl_name">{6}</span> {5} <span class="decl_args">:</span> \
+      <div class="decl_header"><span class="decl_name">{6}</span> {9} {5} <span class="decl_args">:</span> \
       <div class="decl_type">{1}</div></div>\n{2} \
-      <ul>\n{9}\n{3}\n{7}\n{8}\n{10}\n</ul></div>'.format(
+      <ul>\n{3}\n{7}\n{8}\n{10}\n</ul></div>'.format(
       obj['name'], type, doc_string, attr_string, kind, args, name, sfs, cstrs, impl_string, inst_string)
   )
 

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -183,10 +183,16 @@ ul {
     color: darkslategray;
 }
 
-.decl_header {
-    font-size: 15px;
+.decl_header, .attributes {
     font-weight: bold;
     line-height: 1.5;
+}
+
+.decl_header {
+    font-size: 15px;
+}
+
+.decl_header {
     /* indent everything but first line twice as much as decl_type */
     text-indent: -8ex; padding-left: 8ex;
 }
@@ -196,7 +202,7 @@ ul {
     margin-left: 4ex; /* extra indentation */
 }
 
-code, .decl_header,
+code, .decl_header, .attributes,
  .structure .structure_fields .structure_field,
  .inductive .structure_fields .structure_field {
     font-family: monospace;

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -108,7 +108,8 @@ body {
 }
 
 .def .decl_name:before {
-    content: "def "
+    content: "def ";
+    color: blue;
 }
 
 .thm {
@@ -116,11 +117,13 @@ body {
 }
 
 .thm .decl_name:before {
-    content: "theorem "
+    content: "theorem ";
+    color: blue;
 }
 
 .ax .decl_name:before {
-    content: "axiom "
+    content: "axiom ";
+    color: blue;
 }
 
 .ax, .cnst {
@@ -128,7 +131,8 @@ body {
 }
 
 .cnst .decl_name:before {
-    content: "constant "
+    content: "constant ";
+    color: blue;
 }
 
 .structure, .inductive {
@@ -136,11 +140,13 @@ body {
 }
 
 .structure .decl_name:before {
-    content: "structure "
+    content: "structure ";
+    color: blue;
 }
 
 .inductive .decl_name:before {
-    content: "inductive "
+    content: "inductive ";
+    color: blue;
 }
 
 .decl_name, .decl_args {

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -97,14 +97,14 @@ body {
 }
 
 .def, .thm, .ax, .cnst, .structure, .inductive {
-    padding: 8px 8px 8px 8px;
-    border-radius: 8px;
-    /* margin-top: 10px; */
-    margin-bottom: 10px;
+    padding-left: 8px;
+    padding-right: 8px;
+    margin-top: 20px;
+    margin-bottom: 20px;
 }
 
 .def {
-    background-color: #DAE0F2;
+    border-left: 10px solid #92dce5;
 }
 
 .def .decl_name:before {
@@ -112,23 +112,19 @@ body {
 }
 
 .thm {
-    background-color:#DACEE0;
+    border-left: 10px solid #8fe388;
 }
 
 .thm .decl_name:before {
     content: "theorem "
 }
 
-.ax {
-    background-color:#88A0A8;
-}
-
 .ax .decl_name:before {
     content: "axiom "
 }
 
-.cnst {
-    background-color: #88A0A8;
+.ax, .cnst {
+    border-left: 10px solid #f44708;
 }
 
 .cnst .decl_name:before {
@@ -136,7 +132,7 @@ body {
 }
 
 .structure, .inductive {
-    background-color: #92AFD7;
+    border-left: 10px solid #f0a202;
 }
 
 .structure .decl_name:before {

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -189,7 +189,8 @@ ul {
 
 .decl_type {
     font-size:15px;
-    padding: 10px 0px 0px 0px;
+    margin-top: 10px;
+    margin-left: 4ex;
 }
 
 code, .decl_name, .decl_args, .decl_type,

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -97,7 +97,6 @@ body {
 }
 
 .def, .thm, .ax, .cnst, .structure, .inductive {
-    padding-left: 8px;
     padding-right: 8px;
     margin-top: 20px;
     margin-bottom: 20px;
@@ -184,18 +183,20 @@ ul {
     color: darkslategray;
 }
 
-.decl_name, .decl_args {
+.decl_header {
     font-size: 15px;
     font-weight: bold;
+    line-height: 1.5;
+    /* indent everything but first line twice as much as decl_type */
+    text-indent: -8ex; padding-left: 8ex;
 }
 
 .decl_type {
-    font-size:15px;
-    margin-top: 10px;
-    margin-left: 4ex;
+    margin-top: 2px;
+    margin-left: 4ex; /* extra indentation */
 }
 
-code, .decl_name, .decl_args, .decl_type,
+code, .decl_header,
  .structure .structure_fields .structure_field,
  .inductive .structure_fields .structure_field {
     font-family: monospace;

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -248,3 +248,24 @@ a.file:link, a.file:visited, a.file:active {
 .internal_nav .gh_link {
     padding-bottom: 1.5em;
 }
+
+.impl_args.collapsed {
+    cursor: pointer;
+}
+.impl_args.collapsed > span {
+    display: none;
+}
+.impl_args.collapsed:after {
+    content: '{…}';
+}
+
+.impl_args:not(.collapsed):after {
+    /* insert line break after expanded implicit arguments */
+    content: '\A';
+    white-space: pre;
+}
+
+.impl_args {
+    font-style: italic;
+    font-weight: normal;
+}

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -108,7 +108,6 @@ body {
 
 .def .decl_name:before {
     content: "def ";
-    color: blue;
 }
 
 .thm {
@@ -117,12 +116,10 @@ body {
 
 .thm .decl_name:before {
     content: "theorem ";
-    color: blue;
 }
 
 .ax .decl_name:before {
     content: "axiom ";
-    color: blue;
 }
 
 .ax, .cnst {
@@ -131,7 +128,6 @@ body {
 
 .cnst .decl_name:before {
     content: "constant ";
-    color: blue;
 }
 
 .structure, .inductive {
@@ -140,12 +136,10 @@ body {
 
 .structure .decl_name:before {
     content: "structure ";
-    color: blue;
 }
 
 .inductive .decl_name:before {
     content: "inductive ";
-    color: blue;
 }
 
 .decl_name, .decl_args {

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -255,23 +255,20 @@ a.file:link, a.file:visited, a.file:active {
     padding-bottom: 1.5em;
 }
 
-.impl_args.collapsed {
-    cursor: pointer;
-}
-.impl_args.collapsed > span {
+.decl_header.impl_collapsed .impl_arg > span {
     display: none;
 }
-.impl_args.collapsed:after {
+
+.decl_header.impl_collapsed .impl_arg ~ .impl_arg {
+    display: none;
+}
+
+.decl_header.impl_collapsed .impl_arg:after {
+    cursor: pointer;
     content: '{…}';
 }
 
-.impl_args:not(.collapsed):after {
-    /* insert line break after expanded implicit arguments */
-    content: '\A';
-    white-space: pre;
-}
-
-.impl_args {
+.impl_arg {
     font-style: italic;
     font-weight: normal;
 }


### PR DESCRIPTION
 * To improve contrast, just show a small colored stripe on the left side of declarations instead of using background colors.  Also use brighter (and IMHO friendlier) colors.
 * Show attributes above declarations using the `@[simp]` syntax.
 * Indent the second line of the declaration (i.e., the type).
 * Move implicit arguments into the declaration (right before the explicit arguments), and collapse them by default.  Clicking on the ellipsis expands them.

The last change (wrt the implicit arguments) may be a bit controversial, however I found the current list below the docstring to be very cluttered and for some reason distracting.

![doc-gen-new-style](https://user-images.githubusercontent.com/313929/70920673-41e9b180-2023-11ea-9c11-1cb4e6631970.png)
