### PR TITLE
declaration names link to anchor; github links at bottom

### DIFF
--- a/print_docs.py
+++ b/print_docs.py
@@ -214,7 +214,7 @@ search_snippet = """
 def write_internal_nav(objs, filename, out):
   out.write('<h1>Lean <a href="https://leanprover-community.github.io">mathlib</a> docs</h1>')
   out.write('<h2><a href="#top">{0}</a></h2>'.format(filename_import(filename)))
-  out.write('<div class="gh_link"><a href="{}">(view source on GitHub)</a></div>'.format(library_link(filename)))
+  out.write('<div class="gh_nav_link"><a href="{}">View source</a></div>'.format(library_link(filename)))
   for o in sorted([o['name'] for o in objs]):
     out.write('<a href="#{0}">{0}</a><br>\n'.format(o))
 

--- a/print_docs.py
+++ b/print_docs.py
@@ -192,9 +192,9 @@ def write_decl_html(obj, loc_map, instances, out):
   else:
     inst_string = ''
 
-  gh_link = '<div class="gh_link"><a href="{0}">View declaration on GitHub</a></div>'.format(library_link(obj['filename'], obj['line']))
+  gh_link = '<div class="gh_link"><a href="{0}">view source</a></div>'.format(library_link(obj['filename'], obj['line']))
 
-  out.write('<div class="decl {kind}" id="{raw_name}">{decl_code} {sfs} {cstrs} {doc_string} {eqns} {inst_string} {gh_link}</ul></div>'.format(
+  out.write('<div class="decl {kind}" id="{raw_name}">{gh_link} {decl_code} {sfs} {cstrs} {doc_string} {eqns} {inst_string}</ul></div>'.format(
       decl_code = decl_code,
       raw_name = obj['name'],
       doc_string = doc_string,

--- a/print_docs.py
+++ b/print_docs.py
@@ -155,7 +155,7 @@ def write_decl_html(obj, loc_map, instances, out):
 
   is_meta = '<span class="decl_meta">meta</span>' if obj['is_meta'] else ''
   attr_string = '<div class="attributes">@[' + ', '.join(obj['attributes']) + ']</div>' if len(obj['attributes']) > 0 else ''
-  name = '<a href="{0}">{1}</a>'.format(library_link(obj['filename'], obj['line']), obj['name'])
+  name = '<a href="{0}#{1}">{2}</a>'.format(filename_core(site_root, obj['filename'], 'html'), obj['name'], obj['name'])
   args = []
   for s in obj['args']:
     arg = '<span class="decl_args">{}</span>'.format(linkify_linked(s['arg'], loc_map))
@@ -192,7 +192,9 @@ def write_decl_html(obj, loc_map, instances, out):
   else:
     inst_string = ''
 
-  out.write('<div class="decl {kind}" id="{raw_name}">{decl_code} {sfs} {cstrs} {doc_string} {eqns} {inst_string}</ul></div>'.format(
+  gh_link = '<div class="gh_link"><a href="{0}">View declaration on GitHub</a></div>'.format(library_link(obj['filename'], obj['line']))
+
+  out.write('<div class="decl {kind}" id="{raw_name}">{decl_code} {sfs} {cstrs} {doc_string} {eqns} {inst_string} {gh_link}</ul></div>'.format(
       decl_code = decl_code,
       raw_name = obj['name'],
       doc_string = doc_string,
@@ -201,6 +203,7 @@ def write_decl_html(obj, loc_map, instances, out):
       sfs = sfs,
       cstrs = cstrs,
       inst_string = inst_string,
+      gh_link = gh_link
   ))
 
 search_snippet = """

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -266,11 +266,14 @@ a.file:link, a.file:visited, a.file:active {
     font-weight: normal;
 }
 
+.gh_link {
+    float: right;
+}
+
 .gh_link:before {
     content: "";
-    display: block;
+    display: inline-block;
     background: url(https://leanprover-community.github.io/assets/img/gh_logo.png) no-repeat;
     width: 16px;
     height: 13px;
-    float: left;
 }

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -104,18 +104,30 @@ body {
 
 .def {
     border-left: 10px solid #92dce5;
+    border-right: 10px solid #92dce5;
+    border-top: 2px solid #92dce5;
+    border-bottom: 2px solid #92dce5;
 }
 
 .theorem {
     border-left: 10px solid #8fe388;
+    border-right: 10px solid #8fe388;
+    border-top: 2px solid #8fe388;
+    border-bottom: 2px solid #8fe388;
 }
 
 .axiom, .constant {
     border-left: 10px solid #f44708;
+    border-right: 10px solid #f44708;
+    border-top: 2px solid #f44708;
+    border-bottom: 2px solid #f44708;
 }
 
 .structure, .inductive {
     border-left: 10px solid #f0a202;
+    border-right: 10px solid #f0a202;
+    border-top: 2px solid #f0a202;
+    border-bottom: 2px solid #f0a202;
 }
 
 .decl_name, .decl_args {
@@ -244,7 +256,7 @@ a.file:link, a.file:visited, a.file:active {
     padding: 0px;
 }
 
-.internal_nav .gh_link {
+.internal_nav .gh_nav_link {
     padding-bottom: 1.5em;
 }
 
@@ -268,9 +280,10 @@ a.file:link, a.file:visited, a.file:active {
 
 .gh_link {
     float: right;
+    margin-left: 20px;
 }
 
-.gh_link:before {
+.gh_link:before, .internal_nav .gh_nav_link:before {
     content: "";
     display: inline-block;
     background: url(https://leanprover-community.github.io/assets/img/gh_logo.png) no-repeat;

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -104,30 +104,22 @@ body {
 
 .def {
     border-left: 10px solid #92dce5;
-    border-right: 10px solid #92dce5;
     border-top: 2px solid #92dce5;
-    border-bottom: 2px solid #92dce5;
 }
 
 .theorem {
     border-left: 10px solid #8fe388;
-    border-right: 10px solid #8fe388;
     border-top: 2px solid #8fe388;
-    border-bottom: 2px solid #8fe388;
 }
 
 .axiom, .constant {
     border-left: 10px solid #f44708;
-    border-right: 10px solid #f44708;
     border-top: 2px solid #f44708;
-    border-bottom: 2px solid #f44708;
 }
 
 .structure, .inductive {
     border-left: 10px solid #f0a202;
-    border-right: 10px solid #f0a202;
     border-top: 2px solid #f0a202;
-    border-bottom: 2px solid #f0a202;
 }
 
 .decl_name, .decl_args {

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -265,3 +265,12 @@ a.file:link, a.file:visited, a.file:active {
     font-style: italic;
     font-weight: normal;
 }
+
+.gh_link:before {
+    content: "";
+    display: block;
+    background: url(https://leanprover-community.github.io/assets/img/gh_logo.png) no-repeat;
+    width: 16px;
+    height: 13px;
+    float: left;
+}


### PR DESCRIPTION
The declaration names now link to their own position on the page.

Maybe the spacing needs to be adjusted a little, I'm not sure. (Or we could use a normal bullet point.)

![gh_link](https://user-images.githubusercontent.com/4967469/71018893-9e1f0500-20f9-11ea-8577-2ebd51b9f1ff.png)
