### PR TITLE
display and link to library notes

### DIFF
--- a/print_docs.py
+++ b/print_docs.py
@@ -227,7 +227,6 @@ def write_internal_nav(objs, filename, out):
 def write_notes_nav(notes, out):
   out.write('<h1>Lean <a href="https://leanprover-community.github.io">mathlib</a> docs</h1>')
   out.write('<h2><a href="#top">Library notes</a></h2>')
-  out.write('<div class="gh_link"></div>')
   for o in sorted([o[0] for o in notes]):
     out.write('<a href="#{0}">{0}</a><br>\n'.format(o))
 
@@ -341,6 +340,7 @@ badly formatted doc strings, or to add missing documentation.</p>
 """.format(mathlib_commit, mathlib_github_root, lean_root, lean_commit, search_snippet)
 
 notes_body = """
+<a id="top"></a>
 <h1>Lean mathlib notes</h1>
 
 <p>Various implementation details are noted in the mathlib source, and referenced later on.

--- a/print_docs.py
+++ b/print_docs.py
@@ -55,10 +55,12 @@ mathlib_github_src_root = "{0}/blob/{1}/src/".format(mathlib_github_root, mathli
 lean_commit = subprocess.check_output(['lean', '--run', 'src/lean_commit.lean']).decode()
 lean_root = 'https://github.com/leanprover-community/lean/blob/{}/library/'.format(lean_commit)
 
-note_regex = re.compile(r'Note \[(.*)\]:([\s\S]*)')
+note_regex = re.compile(r'Note \[(.*)\]')
+target_url_regex = site_root + r'notes.html#\1'
+link_patterns = [(note_regex, target_url_regex)]
 
 def convert_markdown(ds):
-  return markdown2.markdown(ds, extras=['code-friendly', 'cuddled-lists', 'fenced-code-blocks'])
+  return markdown2.markdown(ds, extras=['code-friendly', 'cuddled-lists', 'fenced-code-blocks', 'link-patterns'], link_patterns = link_patterns)
 
 def filename_core(root, filename, ext):
   if 'lean/library' in filename:
@@ -150,7 +152,7 @@ def linkify_markdown(string, loc_map):
   return re.sub(r'<code>([\s\S]*?)<\/code>', lambda p: linkify_type(p.group(), loc_map), string)
 
 def write_decl_html(obj, loc_map, instances, out):
-  doc_string = markdown2.markdown(obj['doc_string'], extras=["code-friendly", 'cuddled-lists', 'fenced-code-blocks'])
+  doc_string = markdown2.markdown(obj['doc_string'], extras=["code-friendly", 'cuddled-lists', 'fenced-code-blocks', 'link-patterns'], link_patterns = link_patterns)
 
   kind = 'structure' if len(obj['structure_fields']) > 0 else 'inductive' if len(obj['constructors']) > 0 else obj['kind']
   if kind == 'thm': kind = 'theorem'

--- a/print_docs.py
+++ b/print_docs.py
@@ -55,7 +55,7 @@ mathlib_github_src_root = "{0}/blob/{1}/src/".format(mathlib_github_root, mathli
 lean_commit = subprocess.check_output(['lean', '--run', 'src/lean_commit.lean']).decode()
 lean_root = 'https://github.com/leanprover-community/lean/blob/{}/library/'.format(lean_commit)
 
-note_regex = re.compile(r'Note \[(.*)\]')
+note_regex = re.compile(r'Note \[(.*)\]', re.I)
 target_url_regex = site_root + r'notes.html#\1'
 link_patterns = [(note_regex, target_url_regex)]
 

--- a/src/export_json.lean
+++ b/src/export_json.lean
@@ -237,6 +237,12 @@ do map ← get_instances,
    let lst := map.to_list.map (λ ⟨n, l⟩, to_string format!"\"{n}\" : {repr l}"),
    return $ "{" ++ (string.join (lst.intersperse ",")) ++ "}"
 
+meta def format_notes : tactic string :=
+do l ← get_library_notes,
+   let l := l.map $ λ ⟨l, r⟩, to_string $ format!"[{repr l}, {repr r}]",
+   let l := string.join $ l.intersperse ", ",
+   return $ to_string $ format!"[{l}]"
+
 /-- Using `environment.mfold` is much cleaner. Unfortunately this led to a segfault, I think because
 of a stack overflow. Converting the environment to a list of declarations and folding over that led
 to "deep recursion detected". Instead, we split that list into 8 smaller lists and process them
@@ -251,6 +257,8 @@ do handle ← mk_file_handle filename mode.write,
    put_str_ln handle "],",
    ods ← run_tactic write_olean_docs,
    put_str_ln handle $ "\"mod_docs\": {" ++ string.join (ods.intersperse ",\n") ++ "},",
+   notes ← run_tactic format_notes,
+   put_str_ln handle $ "\"notes\": " ++ notes ++ ",",
    instl ← run_tactic format_instance_list,
    put_str_ln handle $ "\"instances\": " ++ instl ++ "}",
    close handle

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -96,7 +96,7 @@ body {
     padding-left: 8px;
 }
 
-.decl, .inductive {
+.decl, .inductive, .note {
     padding-right: 8px;
     margin-top: 20px;
     margin-bottom: 20px;
@@ -120,6 +120,11 @@ body {
 .structure, .inductive {
     border-left: 10px solid #f0a202;
     border-top: 2px solid #f0a202;
+}
+
+.note {
+    border-left: 10px solid #0479c7;
+    padding-left: 8px;
 }
 
 .decl_name, .decl_args {

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -124,6 +124,7 @@ body {
 
 .note {
     border-left: 10px solid #0479c7;
+    border-top: 2px solid #0479c7;
     padding-left: 8px;
 }
 


### PR DESCRIPTION
Adds a page "Notes" that contains all notes declared with the `library_note` command, and links `Note [note name]` to the corresponding point on that page. There's only one instance of this in the library afaict, in the `algebra.category.Mon.basic` module doc.

![Screenshot from 2019-12-18 17-54-20](https://user-images.githubusercontent.com/4967469/71107638-c4a87300-21c1-11ea-8cad-194457af4313.png)
![Screenshot from 2019-12-18 18-08-47](https://user-images.githubusercontent.com/4967469/71107641-c5d9a000-21c1-11ea-967b-9483505a1bff.png)

