### PR TITLE
Display tactics.md in docs

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,4 +5,4 @@ lean_version = "3.5c"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "699da421ea1a19c3b024bf8c02d6f1dd1d7e89d3"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "fe48eb47a45be7e5e3eae2ed72376963620765f3"}

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,4 +5,4 @@ lean_version = "3.5c"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "fe48eb47a45be7e5e3eae2ed72376963620765f3"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "c3db74b343be8ff0584c50f93bf38d16637ecefc"}

--- a/print_docs.py
+++ b/print_docs.py
@@ -434,6 +434,8 @@ def write_site_map(partition):
   out = open_outfile(html_root + 'sitemap.txt', 'w')
   for filename in partition:
     out.write(filename_core(site_root, filename, 'html') + '\n')
+  for n in ['index', 'tactics', 'commands', 'hole_commands', 'notes']:
+    out.write(site_root + n + '.html\n')
   out.close()
 
 def copy_css(path, use_symlinks):

--- a/print_docs.py
+++ b/print_docs.py
@@ -303,7 +303,9 @@ def print_dir_tree(path, active_path, tree):
 def content_nav(dir_list, active_path):
   s = '<div class="search">{}</div>\n'.format(search_snippet)
   s += '<a href="{0}">index</a><br>\n'.format(site_root)
-  s += '<a href="{0}tactics.html">tactics</a><br><br>\n'.format(site_root)
+  s += '<a href="{0}tactics.html">tactics</a><br>\n'.format(site_root)
+  s += '<a href="{0}commands.html">commands</a><br>\n'.format(site_root)
+  s += '<a href="{0}hole_commands.html">hole commands</a><br>\n'.format(site_root)
   s += '<a href="{0}notes.html">notes</a><br><br>\n'.format(site_root)
   s += print_dir_tree('', active_path, dir_list)
   return s
@@ -326,16 +328,16 @@ def split_tactic_list(markdown):
   entries = re.findall(r'(?<=# )(.*)([\s\S]*?)(?=##)', markdown)
   return entries[0], entries[1:]
 
-def write_tactic_doc_file(source, loc_map, dir_list):
+def write_tactic_doc_file(source, name, loc_map, dir_list):
   with open(source, 'r') as infile:
     intro, entries = split_tactic_list(infile.read())
     infile.close()
   entries.sort(key = lambda p: (str.lower(p[0]), str.lower(p[1])))
-  out = open_outfile(html_root + 'tactics.html', 'w')
-  out.write(html_head('mathlib tactics'))
+  out = open_outfile(html_root + name + '.html', 'w')
+  out.write(html_head(name))
   out.write('<div class="column left"><div class="internal_nav">\n' )
   out.write('<h1>Lean <a href="https://leanprover-community.github.io">mathlib</a> docs</h1>')
-  out.write('<h2><a href="#top">Tactics</a></h2>')
+  out.write('<h2><a href="#top">{0}</a></h2>'.format(name))
   for e in entries:
     out.write('<a href="#{0}">{0}</a><br>\n'.format(e[0]))
   out.write('</div></div>\n')
@@ -424,7 +426,9 @@ def write_html_files(partition, loc_map, notes, mod_docs, instances):
   out.write(html_tail)
   out.close()
   write_note_file(notes, loc_map, dir_list)
-  write_tactic_doc_file(local_lean_root + 'docs/tactics.md', loc_map, dir_list)
+  write_tactic_doc_file(local_lean_root + 'docs/tactics.md', 'tactics', loc_map, dir_list)
+  write_tactic_doc_file(local_lean_root + 'docs/commands.md', 'commands', loc_map, dir_list)
+  write_tactic_doc_file(local_lean_root + 'docs/holes.md', 'hole_commands', loc_map, dir_list)
 
 def write_site_map(partition):
   out = open_outfile(html_root + 'sitemap.txt', 'w')

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -293,7 +293,7 @@ a.file:link, a.file:visited, a.file:active {
     height: 13px;
 }
 
-.content.docfile h2 {
+.content.docfile h2, .note h2 {
     margin-block-start: 0em;
     margin-block-end: 0em;
 }

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -294,8 +294,8 @@ a.file:link, a.file:visited, a.file:active {
 }
 
 .content.docfile h2, .note h2 {
-    margin-block-start: 0em;
-    margin-block-end: 0em;
+    margin-block-start: 3px;
+    margin-block-end: 0px;
 }
 
 .content.docfile h2 a {

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -16,6 +16,10 @@ body {
     padding: 15px;
   }
 
+  .content h1 {
+      margin-block-start: 0em;
+  }
+
 /* note: .left and .right are flipped */
   .right {
       position: fixed;
@@ -91,12 +95,12 @@ body {
 }
 
 
-.decl, .mod_doc, .index_body {
+.decl, .mod_doc, .index_body, .tactic {
     overflow-x: auto;
     padding-left: 8px;
 }
 
-.decl, .inductive, .note {
+.decl, .inductive, .note, .tactic {
     padding-right: 8px;
     margin-top: 20px;
     margin-bottom: 20px;
@@ -122,7 +126,7 @@ body {
     border-top: 2px solid #f0a202;
 }
 
-.note {
+.note, .tactic {
     border-left: 10px solid #0479c7;
     border-top: 2px solid #0479c7;
     padding-left: 8px;
@@ -287,4 +291,21 @@ a.file:link, a.file:visited, a.file:active {
     background: url(https://leanprover-community.github.io/assets/img/gh_logo.png) no-repeat;
     width: 16px;
     height: 13px;
+}
+
+.content.docfile h2 {
+    margin-block-start: 0em;
+    margin-block-end: 0em;
+}
+
+.content.docfile h2 a {
+    color: black;
+}
+
+.content.docfile h2 a:link, .content.docfile h2 a:visited, .content.docfile h2 a:active {
+    color: black;
+}
+
+.content.docfile h2 a:hover {
+    color: darkslategray;
 }


### PR DESCRIPTION
I'll work on other doc files later -- the general idea can be reused. But in order to put tactic entries in divs, we need to do some manual markdown processing. This makes it convenient to sort the entries by name.

~~This depends on changing `###` to `##` in `tactics.md`, a pull request coming soon to mathlib.~~
Never mind, it doesn't actually matter, so I won't make the change.

![Screenshot_20191219_163508](https://user-images.githubusercontent.com/4967469/71186490-9ab48680-227d-11ea-9240-ec2ddc08a65b.png)
