### PR TITLE
add mathjax to header so docs can use latex with the usual delimiters

### DIFF
--- a/print_docs.py
+++ b/print_docs.py
@@ -260,6 +260,12 @@ def write_body_content(objs, loc_map, filename, mod_docs, instances, body_out):
     else:
       write_mod_doc(o, loc_map, body_out)
 
+# MathJax configuration docs:
+#   http://docs.mathjax.org/en/latest/options/document.html#the-configuration-block
+# MathJax inlineMath/displayMath docs:
+#   http://docs.mathjax.org/en/latest/options/input/tex.html#tex-extension-options
+# StackOverflow link on why to avoid \(..\) and \[..\] when markdown is in the loop:
+#   https://math.meta.stackexchange.com/a/18714
 def html_head(title):
   return """<!DOCTYPE html>
 <html lang="en">
@@ -272,11 +278,20 @@ def html_head(title):
         <script>
         MathJax = {{
           tex: {{
-            inlineMath: [['$', '$'], ['\\(', '\\)']]
+            inlineMath: [['$', '$']],
+            displayMath: [['$$', '$$']]
           }},
-          svg: {{
-            fontCache: 'global'
-          }}
+          options: {{
+              skipHtmlTags: [
+                  'script', 'noscript', 'style', 'textarea', 'pre',
+                  'code', 'annotation', 'annotation-xml',
+                  'decl', 'decl_meta', 'attributes', 'decl_args', 'decl_header', 'decl_name',
+                  'decl_type', 'equation', 'equations', 'structure_field', 'structure_fields',
+                  'constructor', 'constructors', 'instances'
+              ],
+              ignoreHtmlClass: 'tex2jax_ignore',
+              processHtmlClass: 'tex2jax_process',
+          }},
         }};
         </script>
         <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>

--- a/print_docs.py
+++ b/print_docs.py
@@ -268,6 +268,18 @@ def html_head(title):
         <link rel="shortcut icon" href="https://leanprover-community.github.io/assets/img/lean.ico">
         <title>mathlib docs: {1}</title>
         <meta charset="UTF-8">
+        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+        <script>
+        MathJax = {{
+          tex: {{
+            inlineMath: [['$', '$'], ['\\(', '\\)']]
+          }},
+          svg: {{
+            fontCache: 'global'
+          }}
+        }};
+        </script>
+        <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     </head>
     <body>
         <div class="row">""".format(site_root, title)


### PR DESCRIPTION
This is one way to enhance the docs with LaTeX. The authors of mathlib can simply add math in the comments with the usual delimiters. These pass through into json_export.txt (escaped appropriately for json), and then directly into the HTML. I confirmed this end to end. The only change I had to make was to add MathJax to the header of each page, so it can find the delimited math and render it.