### PR TITLE
Style: make <, ≤, >, ≥ looks better by removing links

### DIFF
--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -227,14 +227,20 @@ code {
 code a:link, code a:visited, code a:active,
 .decl a:link, .decl a:visited, .decl a:active {
     color: black;
-    /** Don't show underline on types, to prevent the ≤ vs < confusion. **/
+}
+
+/** Don't show underline on types, to prevent the ≤ vs < confusion. **/
+.decl_type a:link, .structure_field a:link {
     text-decoration: none;
+}
+
+/** Show it on hover though. **/
+.decl_type a:hover, .structure_field a:hover {
+    text-decoration: underline;
 }
 
 code a:hover, .decl a:hover {
     color: darkslategray;
-    /** Show it on hover though. **/
-    text-decoration: underline;
 }
 
 .indent {

--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -227,10 +227,14 @@ code {
 code a:link, code a:visited, code a:active,
 .decl a:link, .decl a:visited, .decl a:active {
     color: black;
+    /** Don't show underline on types, to prevent the ≤ vs < confusion. **/
+    text-decoration: none;
 }
 
 code a:hover, .decl a:hover {
     color: darkslategray;
+    /** Show it on hover though. **/
+    text-decoration: underline;
 }
 
 .indent {


### PR DESCRIPTION
Those are only enabled upon hovering on them.