### PR TITLE
add page to look up by decl name

### DIFF
--- a/find.html
+++ b/find.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+        <script src="json_output.js"></script>
+        <script src="redirect.js"></script>
+    </head>
+</html>

--- a/find.html
+++ b/find.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <script src="json_output.js"></script>
+        <script src="decl_looup.js"></script>
         <script src="redirect.js"></script>
     </head>
 </html>

--- a/print_docs.py
+++ b/print_docs.py
@@ -683,12 +683,12 @@ def write_json_file(loc_map):
   html_loc_map = {}
   for k in loc_map:
     html_loc_map[k] = loc_in_docs(loc_map, k)
-  out = open_outfile(html_root + 'json_output.js', 'w')
+  out = open_outfile(html_root + 'decl_lookup.js', 'w')
   out.write('var json_str = "' + json.dumps(html_loc_map).replace('"','\\"') + '"')
   out.close()
 
 file_map, loc_map, notes, mod_docs, instances, tactic_docs = load_json()
-#write_html_files(file_map, loc_map, notes, mod_docs, instances, tactic_docs)
+write_html_files(file_map, loc_map, notes, mod_docs, instances, tactic_docs)
 write_json_file(loc_map)
 copy_css(html_root, use_symlinks=cl_args.l)
 write_site_map(file_map)

--- a/redirect.js
+++ b/redirect.js
@@ -1,0 +1,4 @@
+var obj = JSON.parse(json_str);
+var urlParams = new URLSearchParams(window.location.search);
+var declName = urlParams.get('decl')
+window.location.replace(obj[declName] + '#' + declName);


### PR DESCRIPTION
This adds a page `find.html` to the docs. Going to `find.html?decl=nat.add` will redirect you to `core/init/core.html#nat.add`.

Usual disclaimers apply, I don't know anything about web development, probably passing a big json object as a string in a js file isn't the optimal way to do this. What's the better way?