### PR TITLE
blank space at end of lists (closes #23) (closes #14)

### DIFF
--- a/style_js_frame.css
+++ b/style_js_frame.css
@@ -14,6 +14,7 @@ body {
 
   .content {
     padding: 15px;
+    margin-bottom: 100vh;
   }
 
   .content h1 {


### PR DESCRIPTION
I don't think it's particularly elegant, but this adds 1 viewport worth of blank space at the bottom of every middle column so that anchors can always appear at the top of the screen.