### PR TITLE
fix linkification in code blocks

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "."
 version = "0.1"
-lean_version = "leanprover-community/lean:3.17.1"
+lean_version = "leanprover-community/lean:3.18.4"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "f78a012d976ebf3f2a4694fa16cff1632ce0b57f"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "4324778f62a42d4d0cba64680f2362f41b4a8a73"}

--- a/print_docs.py
+++ b/print_docs.py
@@ -201,7 +201,7 @@ def linkify(string, file_map):
 def linkify_type(string, loc_map):
   splitstr = re.split(r'([\s\[\]\(\)\{\}])', string)
   tks = map(lambda s: linkify(s, loc_map), splitstr)
-  return "".join(tks)
+  return f'<code>{"".join(tks)}</code>'
 
 def linkify_linked(string, loc_map):
   return ''.join(
@@ -210,7 +210,7 @@ def linkify_linked(string, loc_map):
     for match in re.findall(r'\ue000(.+?)\ue001(\s*)(.*?)(\s*)\ue002|([^\ue000]+)', string))
 
 def linkify_markdown(string, loc_map):
-  return re.sub(r'<code>([\s\S]*?)<\/code>', lambda p: linkify_type(p.group(), loc_map), string)
+  return re.sub(r'<code>([\s\S]*?)<\/code>', lambda p: linkify_type(p.group(1), loc_map), string)
 
 def link_to_decl(decl_name, loc_map):
   return filename_core(site_root, loc_map[decl_name], 'html') + '#' + decl_name

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -57,7 +57,7 @@
         <summary>Instances</summary>
         <ul>
             {% for inst in instances[decl.name] %}
-                <li>{{ inst | linkify_type }}</li>
+                <li>{{ inst | linkify }}</li>
             {% endfor %}
         </ul>
     </details>

--- a/templates/tactic_doc.j2
+++ b/templates/tactic_doc.j2
@@ -41,7 +41,7 @@
       <details class="rel_decls"><summary>Related declarations</summary>
         <ul>
             {% for d in e.decl_names %}
-                <li>{{ d | linkify_type }}</li>
+                <li>{{ d | linkify }}</li>
             {% endfor %}
         </ul>
       </details>


### PR DESCRIPTION
This linkifies all identifiers found in code blocks, instead of just the ones lucky enough to be caught before.

Then:
![image](https://user-images.githubusercontent.com/4967469/90052879-0dc1b000-dcda-11ea-8a84-bad56096153f.png)


Now:
![image](https://user-images.githubusercontent.com/4967469/90052826-fda9d080-dcd9-11ea-926d-376bb4d088e1.png)
