### PR TITLE
Automatic expression formatting using CSS.

### DIFF
--- a/src/export_json.lean
+++ b/src/export_json.lean
@@ -68,9 +68,6 @@ let decl_names := decl_names.map (repr ∘ to_string),
 "{" ++ to_string (format!"\"name\": {repr name}, \"category\": \"{category}\", \"decl_names\":{decl_names}, \"tags\": {tags}, \"description\": {repr description}, \"import\": {repr imported}") ++ "}"
 end
 
-meta def escape_quotes (s : string) : string :=
-s.fold "" (λ s x, s ++ if x = '"' then '\\'.to_string ++ '"'.to_string else x.to_string)
-
 meta def print_arg : bool × string → string
 | (b, s) := let bstr := if b then "true" else "false" in
 "{" ++ (to_string $ format!"\"arg\":{repr s}, \"implicit\":{bstr}") ++ "}"
@@ -202,7 +199,6 @@ do ff ← d.in_current_file | return none,
    some ⟨line, _⟩ ← return (e.decl_pos decl_name) | return none,
    doc_string ← (some <$> doc_string decl_name) <|> return none,
    (args, type) ← get_args_and_type d.type,
---   type ← escape_quotes <$> to_string <$> pp d.type,
    attributes ← attributes_of decl_name,
    equations ← get_equations decl_name,
    structure_fields ← mk_structure_fields decl_name e,

--- a/src/export_json.lean
+++ b/src/export_json.lean
@@ -57,7 +57,7 @@ meta def compose' : efmt → efmt → efmt
 | a b := compose a b
 
 meta def of_eformat : eformat → efmt
-| (tagged_format.group g) := of_eformat g
+| (tagged_format.group g) := nest (of_eformat g)
 | (tagged_format.nest i g) := nest (of_eformat g)
 | (tagged_format.tag _ g) := of_eformat g
 | (tagged_format.highlight _ g) := of_eformat g

--- a/src/export_json.lean
+++ b/src/export_json.lean
@@ -35,20 +35,54 @@ open tactic io io.fs native
 
 set_option pp.generalized_field_notation true
 
+meta inductive efmt
+| compose (a b : efmt)
+| of_format (f : format)
+| nest (f : efmt)
+
+namespace efmt
+
+meta instance : has_append efmt := ⟨compose⟩
+meta instance : has_coe format efmt := ⟨of_format⟩
+
+meta def to_json : efmt → format
+| (compose a b) := format!"[\"c\",{a.to_json},{b.to_json}]"
+| (of_format f) := repr f.to_string
+| (nest f) := format!"[\"n\",{f.to_json}]"
+
+meta def compose' : efmt → efmt → efmt
+| (of_format a) (of_format b) := of_format (a ++ b)
+| (of_format a) (compose (of_format b) c) := of_format (a ++ b) ++ c
+| (compose a (of_format b)) (of_format c) := a ++ of_format (b ++ c)
+| a b := compose a b
+
+meta def of_eformat : eformat → efmt
+| (tagged_format.group g) := of_eformat g
+| (tagged_format.nest i g) := nest (of_eformat g)
+| (tagged_format.tag _ g) := of_eformat g
+| (tagged_format.highlight _ g) := of_eformat g
+| (tagged_format.compose a b) := compose' (of_eformat a) (of_eformat b)
+| (tagged_format.of_format f) := of_format f
+
+meta def pp (e : expr) : tactic efmt :=
+of_eformat <$> pp_tagged e
+
+end efmt
+
 /-- The information collected from each declaration -/
-structure decl_info :=
+meta structure decl_info :=
 (name : name)
 (is_meta : bool)
-(args : list (bool × string)) -- tt means implicit
-(type : string)
+(args : list (bool × efmt)) -- tt means implicit
+(type : efmt)
 (doc_string : option string)
 (filename : string)
 (line : ℕ)
 (attributes : list string) -- not all attributes, we have a hardcoded list to check
-(equations : list string)
+(equations : list efmt)
 (kind : string) -- def, thm, cnst, ax
-(structure_fields : list (string × string)) -- name and type of fields of a constructor
-(constructors : list (string × string)) -- name and type of constructors of an inductive type
+(structure_fields : list (string × efmt)) -- name and type of fields of a constructor
+(constructors : list (string × efmt)) -- name and type of constructors of an inductive type
 
 structure module_doc_info :=
 (filename : string)
@@ -61,16 +95,19 @@ set_option old_structure_cmd true
 structure ext_tactic_doc_entry extends tactic_doc_entry :=
 (imported : string)
 
+meta def escape_name : name → string :=
+repr ∘ to_string
+
 meta def ext_tactic_doc_entry.to_string : ext_tactic_doc_entry → string
 | ⟨name, category, decl_names, tags, description, _, imported⟩ :=
-let decl_names := decl_names.map (repr ∘ to_string),
+let decl_names := decl_names.map escape_name,
     tags := tags.map repr in
 "{" ++ to_string (format!"\"name\": {repr name}, \"category\": \"{category}\", \"decl_names\":{decl_names}, \"tags\": {tags}, \"description\": {repr description}, \"import\": {repr imported}") ++ "}"
 end
 
-meta def print_arg : bool × string → string
+meta def print_arg : bool × efmt → string
 | (b, s) := let bstr := if b then "true" else "false" in
-"{" ++ (to_string $ format!"\"arg\":{repr s}, \"implicit\":{bstr}") ++ "}"
+"{" ++ (to_string $ format!"\"arg\":{s.to_json}, \"implicit\":{bstr}") ++ "}"
 
 meta def decl_info.to_format : decl_info → format
 | ⟨name, is_meta, args, type, doc_string, filename, line, attributes, equations, kind, structure_fields, constructors⟩ :=
@@ -78,10 +115,10 @@ let doc_string := doc_string.get_or_else "",
     is_meta := if is_meta then "true" else "false",
     args := args.map print_arg,
     attributes := attributes.map repr,
-    equations := equations.map repr,
-    structure_fields := structure_fields.map (λ ⟨n, t⟩, format!"[\"{to_string n}\", {repr t}]"),
-    constructors := constructors.map (λ ⟨n, t⟩, format!"[\"{to_string n}\", {repr t}]") in
-"{" ++ format!"\"name\":\"{to_string name}\", \"is_meta\":{is_meta}, \"args\":{args}, \"type\":{repr type}, \"doc_string\":{repr doc_string}, "
+    equations := equations.map efmt.to_json,
+    structure_fields := structure_fields.map (λ ⟨n, t⟩, format!"[{escape_name n}, {t.to_json}]"),
+    constructors := constructors.map (λ ⟨n, t⟩, format!"[{escape_name n}, {t.to_json}]") in
+"{" ++ format!"\"name\":{escape_name name}, \"is_meta\":{is_meta}, \"args\":{args}, \"type\":{type.to_json}, \"doc_string\":{repr doc_string}, "
     ++ format!"\"filename\":\"{filename}\",\"line\":{line}, \"attributes\":{attributes}, \"equations\":{equations}, "
     ++ format!" \"kind\":{repr kind}, \"structure_fields\":{structure_fields}, \"constructors\":{constructors}" ++ "}"
 
@@ -90,16 +127,20 @@ section
 open tactic.interactive
 
 -- tt means implicit
-private meta def format_binders : list name × binder_info × expr → tactic (bool × format)
-| (ns, binder_info.default, t) := prod.mk ff <$> pformat!"({format_names ns} : {t})"
-| (ns, binder_info.implicit, t) := prod.mk tt <$>  pformat!"{{{format_names ns} : {t}}"
-| (ns, binder_info.strict_implicit, t) := prod.mk tt <$> pformat!"⦃{format_names ns} : {t}⦄"
-| ([n], binder_info.inst_implicit, t) := prod.mk tt <$>
-  if "_".is_prefix_of n.to_string
-    then pformat!"[{t}]"
-    else pformat!"[{format_names [n]} : {t}]"
-| (ns, binder_info.inst_implicit, t) := prod.mk tt <$> pformat!"[{format_names ns} : {t}]"
-| (ns, binder_info.aux_decl, t) := prod.mk tt <$> pformat!"({format_names ns} : {t})"
+meta def format_binders (ns : list name) (bi : binder_info) (t : expr) : tactic (bool × efmt) := do
+t' ← efmt.pp t,
+let use_instance_style : bool := ns.length = 1
+  ∧ "_".is_prefix_of ns.head.to_string
+  ∧ bi = binder_info.inst_implicit,
+let t' := if use_instance_style then t' else format_names ns ++ " : " ++ t',
+let brackets : string × string := match bi with
+  | binder_info.default := ("(", ")")
+  | binder_info.implicit := ("{", "}")
+  | binder_info.strict_implicit := ("⦃", "⦄")
+  | binder_info.inst_implicit := ("[", "]")
+  | binder_info.aux_decl := ("(", ")") -- TODO: is this correct?
+  end,
+pure $ prod.mk (bi ≠ binder_info.default : bool) $ (brackets.1 : efmt) ++ t' ++ brackets.2
 
 meta def binder_info.is_inst_implicit : binder_info → bool
 | binder_info.inst_implicit := tt
@@ -119,13 +160,13 @@ meta def count_named_intros : expr → tactic ℕ
 | _ := 0 -/
 
 -- tt means implicit
-meta def get_args_and_type (e : expr) : tactic (list (bool × string) × string) :=
+meta def get_args_and_type (e : expr) : tactic (list (bool × efmt) × efmt) :=
 prod.fst <$> solve_aux e (
 do count_named_intros e >>= intron,
    cxt ← local_context >>= tactic.interactive.compact_decl,
-   cxt' ← cxt.mmap (λ t, do ft ← format_binders t, return (ft.1, to_string ft.2)),
-   tgt ← target >>= pp,
-   return (cxt', to_string tgt))
+   cxt' ← cxt.mmap (λ t, do ft ← format_binders t.1 t.2.1 t.2.2, return (ft.1, ft.2)),
+   tgt ← target >>= efmt.pp,
+   return (cxt', tgt))
 
 end
 
@@ -150,16 +191,16 @@ meta def enable_links : tactic unit :=
 do o ← get_options, set_options $ o.set_bool `pp.links tt
 
 -- assumes proj_name exists
-meta def get_proj_type (struct_name proj_name : name) : tactic string :=
+meta def get_proj_type (struct_name proj_name : name) : tactic efmt :=
 do (locs, _) ← mk_const struct_name >>= infer_type >>= mk_local_pis,
    proj_tp ← mk_const proj_name >>= infer_type,
    (_, t) ← mk_local_pisn (proj_tp.instantiate_pis locs) 1,
-   to_string <$> pp t
+   efmt.pp t
 
-meta def mk_structure_fields (decl : name) (e : environment) : tactic (list (string × string)) :=
+meta def mk_structure_fields (decl : name) (e : environment) : tactic (list (string × efmt)) :=
 match e.is_structure decl, e.structure_fields_full decl with
 | tt, some proj_names := proj_names.mmap $
-    λ n, do tp ← get_proj_type decl n, return (to_string n, to_string tp)
+    λ n, do tp ← get_proj_type decl n, return (to_string n, tp)
 | _, _ := return []
 end
 
@@ -168,26 +209,26 @@ meta def mk_const_with_params (d : declaration) : expr :=
 let lvls := d.univ_params.map level.param in
 expr.const d.to_name lvls
 
-meta def get_constructor_type (type_name constructor_name : name) : tactic string :=
+meta def get_constructor_type (type_name constructor_name : name) : tactic efmt :=
 do d ← get_decl type_name,
    (locs, _) ← infer_type (mk_const_with_params d) >>= mk_local_pis,
    env ← get_env,
    let locs := locs.take (env.inductive_num_params type_name),
    proj_tp ← mk_const constructor_name >>= infer_type,
    do t ← pis locs (proj_tp.instantiate_pis locs), --.abstract_locals (locs.map expr.local_uniq_name),
-   to_string <$> pp t
+   efmt.pp t
 
-meta def mk_constructors (decl : name) (e : environment): tactic (list (string × string)) :=
+meta def mk_constructors (decl : name) (e : environment): tactic (list (string × efmt)) :=
 if (¬ e.is_inductive decl) ∨ (e.is_structure decl) then return [] else
 do d ← get_decl decl, ns ← get_constructors_for (mk_const_with_params d),
-   ns.mmap $ λ n, do tp ← get_constructor_type decl n, return (to_string n, to_string tp)
+   ns.mmap $ λ n, do tp ← get_constructor_type decl n, return (to_string n, tp)
 
-meta def get_equations (decl : name) : tactic (list string) := do
+meta def get_equations (decl : name) : tactic (list efmt) := do
 ns ← get_eqn_lemmas_for tt decl,
 ns.mmap $ λ n, do
 d ← get_decl n,
 (_, ty) ← mk_local_pis d.type,
-to_string <$> pp ty
+efmt.pp ty
 
 /-- extracts `decl_info` from `d`. Should return `none` instead of failing. -/
 meta def process_decl (d : declaration) : tactic (option decl_info) :=

--- a/style.css
+++ b/style.css
@@ -349,6 +349,7 @@ label[for="nav_toggle"] { /* The MENU button */
     text-indent: -1ch;
     padding-left: 1ch;
     white-space: pre-wrap;
+    vertical-align: top;
 }
 
 .decl_args, .decl_type {

--- a/style.css
+++ b/style.css
@@ -343,8 +343,12 @@ label[for="nav_toggle"] { /* The MENU button */
     border-top: 2px solid #f0a202;
 }
 
-.decl_args {
-    white-space: nowrap;
+.fn {
+    display: inline-block;
+    /* border: 1px dashed red; */
+    text-indent: -1ch;
+    padding-left: 1ch;
+    white-space: pre-wrap;
 }
 
 .decl_args, .decl_type {
@@ -399,6 +403,7 @@ pre code { padding: 0 0; }
     display: block;
     padding-inline-start: 0;
     margin-top: 1ex;
+    text-indent: -2ex; padding-left: 2ex;
 }
 
 .structure_field {

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -14,18 +14,18 @@
     <span class="decl_name"><a href="{{ decl.name | link_to_decl }}">{{ decl.name | htmlify_name }}</a></span>
     {% for arg in decl.args %}
         {% if arg.implicit %}<span class="impl_arg">{% endif %}
-        <span class="decl_args">{{ arg.arg | linkify_linked }}</span>
+        <span class="decl_args">{{ arg.arg | linkify_efmt }}</span>
         {% if arg.implicit %}</span>{% endif %}
     {% endfor %}
     <span class="decl_args">:</span>
-    <div class="decl_type">{{ decl.type | linkify_linked }}</div>
+    <div class="decl_type">{{ decl.type | linkify_efmt }}</div>
 </div>
 
 {% if decl.structure_fields | length %}
     <ul class="structure_fields" id="{{ decl.name }}.mk">
         {% for name, tp in decl.structure_fields %}
             {% set field_name = name.split('.')[-1] %}
-            <li class="structure_field" id="{{name}}">{{field_name}} : {{ tp | linkify_linked }}</li>
+            <li class="structure_field" id="{{name}}">{{field_name}} : {{ tp | linkify_efmt }}</li>
         {% endfor %}
     </ul>
 {% endif %}
@@ -34,7 +34,7 @@
     <ul class="constructors">
         {% for name, tp in decl.constructors %}
             {% set ctor_name = name.split('.')[-1] %}
-            <li class="constructor" id="{{name}}">{{ctor_name}} : {{ tp | linkify_linked }}</li>
+            <li class="constructor" id="{{name}}">{{ctor_name}} : {{ tp | linkify_efmt }}</li>
         {% endfor %}
     </ul>
 {% endif %}
@@ -46,7 +46,7 @@
         <summary>Equations</summary>
         <ul class="equations">
             {% for eqn in decl.equations %}
-                <li class="equation">{{ eqn | linkify_linked }}</li>
+                <li class="equation">{{ eqn | linkify_efmt }}</li>
             {% endfor %}
         </ul>
     </details>


### PR DESCRIPTION
Thanks to @DanielFabian, who introduced this technique in https://github.com/leanprover-community/mathlib/pull/3764

This probably requires a bit more testing, but it's too late for that today.

Demo: https://gebner.github.io/mathlib_docs/logic/relator.html#relator.rel_forall_of_total (resize the browser horizontally)