### PR TITLE
Add html-rendered declaration to export db.

### DIFF
--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -9,16 +9,7 @@
 {% endif %}
 
 <div class="decl_header impl_collapsed">
-    {% if decl.is_meta %}<span class="decl_meta">meta</span>{% endif %}
-    <span class="decl_kind">{{ kind }}</span>
-    <span class="decl_name"><a href="{{ decl.name | link_to_decl }}">{{ decl.name | htmlify_name }}</a></span>
-    {% for arg in decl.args %}
-        {% if arg.implicit %}<span class="impl_arg">{% endif %}
-        <span class="decl_args">{{ arg.arg | linkify_efmt }}</span>
-        {% if arg.implicit %}</span>{% endif %}
-    {% endfor %}
-    <span class="decl_args">:</span>
-    <div class="decl_type">{{ decl.type | linkify_efmt }}</div>
+    {% include "decl_header.j2" %}
 </div>
 
 {% if decl.structure_fields | length %}

--- a/templates/decl_header.j2
+++ b/templates/decl_header.j2
@@ -1,0 +1,11 @@
+{% set kind = kind_of_decl(decl) %}
+{% if decl.is_meta %}<span class="decl_meta">meta</span>{% endif %}
+<span class="decl_kind">{{ kind }}</span>
+<span class="decl_name"><a href="{{ decl.name | link_to_decl }}">{{ decl.name | htmlify_name }}</a></span>
+{% for arg in decl.args %}
+    {% if arg.implicit %}<span class="impl_arg">{% endif %}
+    <span class="decl_args">{{ arg.arg | linkify_efmt }}</span>
+    {% if arg.implicit %}</span>{% endif %}
+{% endfor %}
+<span class="decl_args">:</span>
+<div class="decl_type">{{ decl.type | linkify_efmt }}</div>


### PR DESCRIPTION
Instead of exporting the internal type and argument strings (the U+E000 were never meant to leave doc-gen), export an HTML-rendered version of the declaration statement.