### PR TITLE
Scroll current file to center.

### DIFF
--- a/nav.js
+++ b/nav.js
@@ -26,7 +26,7 @@ for (const elem of document.getElementsByClassName('nav_sect')) {
 }
 
 for (const currentFileLink of document.getElementsByClassName('visible')) {
-  setTimeout(() => currentFileLink.scrollIntoView(), 0);
+  currentFileLink.scrollIntoView({block: 'center'});
 }
 
 


### PR DESCRIPTION
At the moment, the javascript scrolls the current file in the left
navbar to the top of the screen, which I find a bit irritating because
then you can't see the files above it anymore.  This PR changes the
behavior so that it is scrolled into the vertical center of the screen.