### PR TITLE
Gray-out implicit arguments instead of collapsing them

### DIFF
--- a/nav.js
+++ b/nav.js
@@ -34,24 +34,6 @@ for (const currentFileLink of document.getElementsByClassName('visible')) {
 
 
 
-// Expansion of implicit arguments ({...})
-// ---------------------------------------
-
-
-for (const impl_collapsed of document.getElementsByClassName('impl_collapsed')) {
-    const impl_args = impl_collapsed.getElementsByClassName('impl_arg');
-    if (impl_args.length > 0) {
-        impl_args[0].addEventListener('click', () =>
-            impl_collapsed.classList.remove('impl_collapsed'));
-    }
-}
-
-
-
-
-
-
-
 // Tactic list tag filter
 // ----------------------
 

--- a/style.css
+++ b/style.css
@@ -438,19 +438,14 @@ a:hover {
     text-decoration: underline;
 }
 
-.decl_header.impl_collapsed .impl_arg > span {
-    display: none;
-}
-.decl_header.impl_collapsed .impl_arg ~ .impl_arg {
-    display: none;
-}
-.decl_header.impl_collapsed .impl_arg:after {
-    cursor: pointer;
-    content: '{…}';
-}
 .impl_arg {
     font-style: italic;
-    font-weight: normal;
+    transition: opacity 300ms ease-in;
+}
+
+.decl_header:not(:hover) .impl_arg {
+    opacity: 30%;
+    transition: opacity 1000ms ease-out;
 }
 
 .gh_link {

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -8,7 +8,7 @@
     <div class="attributes">@[{{ ', '.join(decl.attributes) }}]</div>
 {% endif %}
 
-<div class="decl_header impl_collapsed">
+<div class="decl_header">
     {% include "decl_header.j2" %}
 </div>
 


### PR DESCRIPTION
At the moment, implicit arguments (including instance-implicit
arguments) are collapsed to `{…}`.  This approach impacts not only
discoverability but it also obscures the theorem statement by omitting
the type-class requirements.

It is particularly annoying that the type-class arguments are not shown
by default, because these are typically critical to understand the
theorem statement.

As an easy fix, this PR proposes to *gray-out* the implicit arguments
instead of programatically hiding them behind an unintuitive `{…}`
button.  As soon as the user hovers over the arguments, the arguments
are shown in full color.  This is done in an eye-pleasing way by setting
appropriate easing animations.

![gray_out_example](https://user-images.githubusercontent.com/313929/91310384-1c1bcb80-e7b2-11ea-9b83-484fed7ecb14.png)
