### PR TITLE
host yaml files from mathlib on docs site

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "."
 version = "0.1"
-lean_version = "leanprover-community/lean:3.18.4"
+lean_version = "leanprover-community/lean:3.19.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "d4d33deaa14500c982022408ad94b4979b7e337f"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "7462be545062a8d0a7ad227cacbdf5d431befdcf"}

--- a/print_docs.py
+++ b/print_docs.py
@@ -397,7 +397,7 @@ def copy_css(path, use_symlinks):
 
 def copy_yaml_files(path):
   for fn in ['100.yaml', 'undergrad.yaml', 'overview.yaml']:
-    shutil.copyfile(f'_target/deps/mathlib/docs/{fn}', path+fn)
+    shutil.copyfile(f'mathlib/docs/{fn}', path+fn)
 
 def write_decl_txt(loc_map):
   with open_outfile('decl.txt') as out:

--- a/print_docs.py
+++ b/print_docs.py
@@ -397,7 +397,7 @@ def copy_css(path, use_symlinks):
 
 def copy_yaml_files(path):
   for fn in ['100.yaml', 'undergrad.yaml', 'overview.yaml']:
-    shutil.copyfile(f'mathlib/docs/{fn}', path+fn)
+    shutil.copyfile(f'{local_lean_root}docs/{fn}', path+fn)
 
 def write_decl_txt(loc_map):
   with open_outfile('decl.txt') as out:

--- a/print_docs.py
+++ b/print_docs.py
@@ -395,6 +395,10 @@ def copy_css(path, use_symlinks):
   cp('nav.js', path+'nav.js')
   cp('searchWorker.js', path+'searchWorker.js')
 
+def copy_yaml_files(path):
+  for fn in ['100.yaml', 'undergrad.yaml', 'overview.yaml']:
+    shutil.copyfile(f'_target/deps/mathlib/docs/{fn}', path+fn)
+
 def write_decl_txt(loc_map):
   with open_outfile('decl.txt') as out:
     out.write('\n'.join(loc_map.keys()))
@@ -433,5 +437,6 @@ if __name__ == '__main__':
   write_html_files(file_map, loc_map, notes, mod_docs, instances, tactic_docs)
   write_redirects(loc_map, file_map)
   copy_css(html_root, use_symlinks=cl_args.l)
+  copy_yaml_files(html_root)
   write_export_db(mk_export_db(loc_map, file_map))
   write_site_map(file_map)


### PR DESCRIPTION
Don't merge yet -- this is pending changes to mathlib. We'll store the overview, undergrad, and 100 theorems yaml file in mathlib instead of in the website, so that we can test them in mathlib CI. Then we'll host them here, to ensure that the website can grab yaml files in sync with the declaration database.