### PR TITLE
Use CSS for line-breaking in definition names rather than invisible characters

### DIFF
--- a/print_docs.py
+++ b/print_docs.py
@@ -231,7 +231,7 @@ def kind_of_decl(decl):
 env.globals['kind_of_decl'] = kind_of_decl
 
 def htmlify_name(n):
-  return '.'.join([f'<span>{ html.escape(part) }</span>' for part in n.split('.')])
+  return '.'.join([f'<span class="name">{ html.escape(part) }</span>' for part in n.split('.')])
 env.filters['htmlify_name'] = htmlify_name
 
 # returns (pagetitle, intro_block), [(tactic_name, tactic_block)]

--- a/print_docs.py
+++ b/print_docs.py
@@ -233,7 +233,7 @@ env.globals['kind_of_decl'] = kind_of_decl
 # Inserts zero-width spaces after dots
 def htmlify_name(n):
   # TODO: html escape
-  return '.&#8203;'.join(n.split('.'))
+  return '.'.join([f'<span>{ part }</span>' for part in n.split('.')])
 env.filters['htmlify_name'] = htmlify_name
 
 # returns (pagetitle, intro_block), [(tactic_name, tactic_block)]

--- a/print_docs.py
+++ b/print_docs.py
@@ -230,10 +230,8 @@ def kind_of_decl(decl):
   return kind
 env.globals['kind_of_decl'] = kind_of_decl
 
-# Inserts zero-width spaces after dots
 def htmlify_name(n):
-  # TODO: html escape
-  return '.'.join([f'<span>{ part }</span>' for part in n.split('.')])
+  return '.'.join([f'<span>{ html.escape(part) }</span>' for part in n.split('.')])
 env.filters['htmlify_name'] = htmlify_name
 
 # returns (pagetitle, intro_block), [(tactic_name, tactic_block)]

--- a/style.css
+++ b/style.css
@@ -374,11 +374,11 @@ ul {
 }
 
 /* break long declaration names at periods where possible */
-.decl_name > a {
+.break_within {
     word-break: break-all;
 }
 
-.decl_name > a > span {
+.break_within .name {
     word-break: normal;
 }
 

--- a/style.css
+++ b/style.css
@@ -373,6 +373,15 @@ ul {
     font-weight: bold;
 }
 
+/* break long declaration names at periods where possible */
+.decl_name > a {
+    word-break: break-all;
+}
+
+.decl_name > a > span {
+    word-break: normal;
+}
+
 .decl_header {
     /* indent everything but first line twice as much as decl_type */
     text-indent: -8ex; padding-left: 8ex;

--- a/templates/base.j2
+++ b/templates/base.j2
@@ -15,7 +15,7 @@
 
 <div class="header">
     <h1><a href="https://leanprover-community.github.io">mathlib</a> <span>documentation</span></h1>
-    <p class="header_filename">{{ self.title() }}</p>
+    <p class="header_filename break_within">{% block doctitle %}{{ self.title() }}{% endblock %}</p>
     <form action="https://google.com/search" method="get" id="search_form">
         <input type="hidden" name="sitesearch" value="https://leanprover-community.github.io/mathlib_docs">
         <input type="text" name="q" autocomplete="off">

--- a/templates/decl_header.j2
+++ b/templates/decl_header.j2
@@ -1,7 +1,7 @@
 {% set kind = kind_of_decl(decl) %}
 {% if decl.is_meta %}<span class="decl_meta">meta</span>{% endif %}
 <span class="decl_kind">{{ kind }}</span>
-<span class="decl_name"><a href="{{ decl.name | link_to_decl }}">{{ decl.name | htmlify_name }}</a></span>
+<span class="decl_name"><a class="break_within" href="{{ decl.name | link_to_decl }}">{{ decl.name | htmlify_name }}</a></span>
 {% for arg in decl.args %}
     {% if arg.implicit %}<span class="impl_arg">{% endif -%}
     <span class="decl_args">{{ arg.arg | linkify_efmt }}</span>

--- a/templates/module.j2
+++ b/templates/module.j2
@@ -1,5 +1,5 @@
 {% extends "base.j2" %}
-{% block title %}{{ filename | filename_import | htmlify_name }}{% endblock %}
+{% block title %}{{ filename | filename_import | e }}{% endblock %}
 
 {% block content %}
 {% for item in items %}

--- a/templates/module.j2
+++ b/templates/module.j2
@@ -1,5 +1,6 @@
 {% extends "base.j2" %}
 {% block title %}{{ filename | filename_import | e }}{% endblock %}
+{% block doctitle %}{{ filename | filename_import | htmlify_name }}{% endblock %}
 
 {% block content %}
 {% for item in items %}
@@ -15,11 +16,11 @@
 {% endblock %}
 
 {% block internal_nav %}
-<h3><a href="#top">{{ self.title() }}</a></h3>
+<h3><a class="break_within" href="#top">{{ self.doctitle() }}</a></h3>
 
 <div class="gh_nav_link"><a href="{{ filename | library_link }}">source</a></div>
 
 {% for decl_name in decl_names %}
-    <div class="nav_link"><a href="#{{ decl_name }}">{{ decl_name | htmlify_name }}</a></div>
+    <div class="nav_link"><a class="break_within" href="#{{ decl_name }}">{{ decl_name | htmlify_name }}</a></div>
 {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Emulate the old line break behaviour, but with CSS rather than zero-width spaces 🎨 . Closes #58