### PR TITLE
Go back to using regular Pygments package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,6 @@ rm -rf _target
 leanproject get-mathlib-cache
 ```
 
-We require a pre-release version of `pygments` for syntax highlighting because the latest release does not include support for Lean 3 yet.  You can also use an older `pygments` for testing if you need to, but then the syntax highlighting will be off.
-
 Make sure that olean files are generated for mathlib in `_target`, otherwise this will be extremely slow.
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 markdown2
 toml
 mathlibtools
-git+https://github.com/pygments/pygments@master#egg=Pygments
+pygments >= 2.7.1
 jinja2


### PR DESCRIPTION
Now Pygments latest releases supports Lean 3, we don't need to use the prerelease version any more 🙂 