### PR TITLE
change highlight colors to match boxes

### DIFF
--- a/style.css
+++ b/style.css
@@ -365,16 +365,20 @@ label[for="nav_toggle"] { /* The MENU button */
 }
 
 .def .fn:hover {
-    background-color: hsla(187, 61%, calc(100% - 4%*var(--fn)));
+    background-color: hsla(187, 61%, calc(100% - 5%*var(--fn)));
+    border-radius: 5px;
 }
 .theorem .fn:hover {
-    background-color: hsla(115, 62%, calc(100% - 4%*var(--fn)));
+    background-color: hsla(115, 62%, calc(100% - 5%*var(--fn)));
+    border-radius: 5px;
 }
 .axiom .fn:hover, .constant .fn:hover {
-    background-color: hsla(16, 94%, calc(100% - 4%*var(--fn)));
+    background-color: hsla(16, 94%, calc(100% - 5%*var(--fn)));
+    border-radius: 5px;
 }
 .structure .fn:hover, .inductive .fn:hover {
-    background-color: hsla(40, 98%, calc(100% - 4%*var(--fn)));
+    background-color: hsla(40, 98%, calc(100% - 5%*var(--fn)));
+    border-radius: 5px;
 }
 
 .decl_args, .decl_type {

--- a/style.css
+++ b/style.css
@@ -365,16 +365,16 @@ label[for="nav_toggle"] { /* The MENU button */
 }
 
 .def .fn:hover {
-    background-color: hsla(calc(187 - (var(--fn) - 1) * 10), 61%, calc(100% - 3%*var(--fn)));
+    background-color: hsla(187, 61%, calc(100% - 4%*var(--fn)));
 }
 .theorem .fn:hover {
-    background-color: hsla(calc(115 - (var(--fn) - 1) * 10), 62%, calc(100% - 3%*var(--fn)));
+    background-color: hsla(115, 62%, calc(100% - 4%*var(--fn)));
 }
 .axiom .fn:hover, .constant .fn:hover {
-    background-color: hsla(calc(16 - (var(--fn) - 1) * 10), 94%, calc(100% - 3%*var(--fn)));
+    background-color: hsla(16, 94%, calc(100% - 4%*var(--fn)));
 }
 .structure .fn:hover, .inductive .fn:hover {
-    background-color: hsla(calc(40 - (var(--fn) - 1) * 10), 98%, calc(100% - 3%*var(--fn)));
+    background-color: hsla(40, 98%, calc(100% - 4%*var(--fn)));
 }
 
 .decl_args, .decl_type {

--- a/style.css
+++ b/style.css
@@ -366,18 +366,22 @@ label[for="nav_toggle"] { /* The MENU button */
 
 .def .fn:hover {
     background-color: hsla(187, 61%, calc(100% - 5%*var(--fn)));
+    box-shadow: 0 0 0 1px hsla(187, 61%, calc(100% - 5%*(var(--fn) + 1)));
     border-radius: 5px;
 }
 .theorem .fn:hover {
     background-color: hsla(115, 62%, calc(100% - 5%*var(--fn)));
+    box-shadow: 0 0 0 1px hsla(115, 62%, calc(100% - 5%*(var(--fn) + 1)));
     border-radius: 5px;
 }
 .axiom .fn:hover, .constant .fn:hover {
     background-color: hsla(16, 94%, calc(100% - 5%*var(--fn)));
+    box-shadow: 0 0 0 1px hsla(16, 94%, calc(100% - 5%*(var(--fn) + 1)));
     border-radius: 5px;
 }
 .structure .fn:hover, .inductive .fn:hover {
     background-color: hsla(40, 98%, calc(100% - 5%*var(--fn)));
+    box-shadow: 0 0 0 1px hsla(40, 98%, calc(100% - 5%*(var(--fn) + 1)));
     border-radius: 5px;
 }
 

--- a/style.css
+++ b/style.css
@@ -363,8 +363,18 @@ label[for="nav_toggle"] { /* The MENU button */
 .fn {
     transition: background-color 100ms ease-in-out;
 }
-.fn:hover {
-    background-color: hsla(calc(75 - var(--fn) * 10), 80%, calc(100% - 3%*var(--fn)));
+
+.def .fn:hover {
+    background-color: hsla(calc(187 - var(--fn) * 10), 61%, calc(100% - 3%*var(--fn)));
+}
+.theorem .fn:hover {
+    background-color: hsla(calc(115 - var(--fn) * 10), 62%, calc(100% - 3%*var(--fn)));
+}
+.axiom .fn:hover, .constant .fn:hover {
+    background-color: hsla(calc(16 - var(--fn) * 10), 94%, calc(100% - 3%*var(--fn)));
+}
+.structure .fn:hover, .inductive .fn:hover {
+    background-color: hsla(calc(40 - var(--fn) * 10), 98%, calc(100% - 3%*var(--fn)));
 }
 
 .decl_args, .decl_type {

--- a/style.css
+++ b/style.css
@@ -365,16 +365,16 @@ label[for="nav_toggle"] { /* The MENU button */
 }
 
 .def .fn:hover {
-    background-color: hsla(calc(187 - var(--fn) * 10), 61%, calc(100% - 3%*var(--fn)));
+    background-color: hsla(calc(187 - (var(--fn) - 1) * 10), 61%, calc(100% - 3%*var(--fn)));
 }
 .theorem .fn:hover {
-    background-color: hsla(calc(115 - var(--fn) * 10), 62%, calc(100% - 3%*var(--fn)));
+    background-color: hsla(calc(115 - (var(--fn) - 1) * 10), 62%, calc(100% - 3%*var(--fn)));
 }
 .axiom .fn:hover, .constant .fn:hover {
-    background-color: hsla(calc(16 - var(--fn) * 10), 94%, calc(100% - 3%*var(--fn)));
+    background-color: hsla(calc(16 - (var(--fn) - 1) * 10), 94%, calc(100% - 3%*var(--fn)));
 }
 .structure .fn:hover, .inductive .fn:hover {
-    background-color: hsla(calc(40 - var(--fn) * 10), 98%, calc(100% - 3%*var(--fn)));
+    background-color: hsla(calc(40 - (var(--fn) - 1) * 10), 98%, calc(100% - 3%*var(--fn)));
 }
 
 .decl_args, .decl_type {


### PR DESCRIPTION
(This is a PR to the `flashy_highlighting` branch from #59)

It duplicates some code (I'm not good enough with CSS to know how to avoid it), but the highlight colors are now based on the colors of the surrounding boxes:

![highlight1](https://user-images.githubusercontent.com/4967469/94127439-3b615380-fe59-11ea-8fa6-1dfb26b84bdd.png)
![highlight2](https://user-images.githubusercontent.com/4967469/94127466-45835200-fe59-11ea-9160-5591a4a5691e.png)

For deeply nested things like the second, the colors do diverge a bit, but I don't think it looks so bad.
