### PR TITLE
fix warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
           cd mathlib
           ~/.elan/bin/lean --version
-          echo "::add-path::$HOME/.elan/bin"
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
       - name: install Python
         uses: actions/setup-python@v1


### PR DESCRIPTION
See https://github.com/leanprover-community/doc-gen/actions/runs/318940811 and https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/