### PR TITLE
Make it possible to call `main` from another python script

### DIFF
--- a/print_docs.py
+++ b/print_docs.py
@@ -334,7 +334,7 @@ def mk_site_tree_core(filenames, path=''):
 
   return entries
 
-def setup_jinja_globals(file_map, loc_map):
+def setup_jinja_globals(file_map, loc_map, instances):
   env.globals['site_tree'] = mk_site_tree(file_map)
   env.globals['instances'] = instances
   env.globals['import_options'] = lambda d, i: import_options(loc_map, d, i)
@@ -462,7 +462,7 @@ def write_export_db(export_db):
 
 def main():
   file_map, loc_map, notes, mod_docs, instances, tactic_docs = load_json()
-  setup_jinja_globals(file_map, loc_map)
+  setup_jinja_globals(file_map, loc_map, instances)
   write_decl_txt(loc_map)
   write_html_files(file_map, loc_map, notes, mod_docs, instances, tactic_docs)
   write_redirects(loc_map, file_map)

--- a/print_docs.py
+++ b/print_docs.py
@@ -460,7 +460,7 @@ def write_export_db(export_db):
   with gzip.GzipFile(html_root + 'export_db.json.gz', 'w') as zout:
     zout.write(json_str.encode('utf-8'))
 
-if __name__ == '__main__':
+def main():
   file_map, loc_map, notes, mod_docs, instances, tactic_docs = load_json()
   setup_jinja_globals(file_map, loc_map)
   write_decl_txt(loc_map)
@@ -471,3 +471,6 @@ if __name__ == '__main__':
   copy_static_files(html_root)
   write_export_db(mk_export_db(loc_map, file_map))
   write_site_map(file_map)
+    
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This makes it possible for me to write a script that does`
```python
import print_docs
del print_docs.extra_doc_files[:]  # these are mathlilb specific
print_docs.main()
```
Obviously this is a hack, but the hack goes in my code not yours :)