### PR TITLE
Improve the tokenizer used by the search engine

### DIFF
--- a/searchWorker.js
+++ b/searchWorker.js
@@ -7,13 +7,13 @@ const declNames = req.responseText.split('\n');
 
 // Adapted from the default tokenizer and
 // https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BZ%7D&abb=on&c=on&esc=on&g=&i=
-const SPACE_OR_DOT = /[.\n\r \u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+/u
+const SEPARATOR = /[._\n\r \u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+/u
 
 importScripts('https://cdn.jsdelivr.net/npm/minisearch@2.4.1/dist/umd/index.min.js');
 const miniSearch = new MiniSearch({
     fields: ['decl'],
     storeFields: ['decl'],
-    tokenize: text => text.split(SPACE_OR_DOT),
+    tokenize: text => text.split(SEPARATOR),
 });
 miniSearch.addAll(declNames.map((decl, id) => ({decl, id})));
 

--- a/searchWorker.js
+++ b/searchWorker.js
@@ -5,10 +5,15 @@ req.send();
 
 const declNames = req.responseText.split('\n');
 
+// Adapted from the default tokenizer and
+// https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BZ%7D&abb=on&c=on&esc=on&g=&i=
+const SPACE_OR_DOT = /[.\n\r \u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+/u
+
 importScripts('https://cdn.jsdelivr.net/npm/minisearch@2.4.1/dist/umd/index.min.js');
 const miniSearch = new MiniSearch({
     fields: ['decl'],
     storeFields: ['decl'],
+    tokenize: text => text.split(SPACE_OR_DOT),
 });
 miniSearch.addAll(declNames.map((decl, id) => ({decl, id})));
 


### PR DESCRIPTION
The default tokenizer used by minisearch splits queries on
any space and punctuation. However, punctuation is significant in Lean.
E.g., `induction'` and `induction` are different.
By using the default tokenizer, a query like `induction'` will not display
`tactic.interactive.induction'`, but instead mostly show results about
`induction`.

This PR supplies a custom tokenizer which splits on any space (\p{Z})
and dot (.). I added dot as a special case to make the search fuzzy.
For example, searching `tactic.induction` probably should show
results of `tactic.interactive.induction`. Without splitting on dot,
the default fuzzy search would find "tactic.interactive.induction" and
"tactic.induction" too different.

The regex is taken from the page in the comment. Note that the default
tokenizer does exactly the same (see
https://github.com/lucaong/minisearch/blob/fa2e104fb7c26fd7f47db7be6a364ec1693ee606/src/MiniSearch.ts#L1169)