### PR TITLE
fix on windows, update mathlib version

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "."
 version = "0.1"
-lean_version = "leanprover-community/lean:3.23.0"
+lean_version = "leanprover-community/lean:3.26.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "5a61ef1981738b829ff712cab18e63a675108c40"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "97f89af64791b5149678fae75ca75fc44912da42"}

--- a/print_docs.py
+++ b/print_docs.py
@@ -478,7 +478,7 @@ def write_src_redirect(decl_name, decl_loc, file_map):
 
 def write_redirects(loc_map, file_map):
   for decl_name in loc_map:
-    if decl_name.startswith('con.') and sys.platform == 'win32':
+    if (decl_name == 'con' or decl_name.startswith('con.')) and sys.platform == 'win32':
       continue  # can't write these files on windows
     write_docs_redirect(decl_name, loc_map[decl_name])
     write_src_redirect(decl_name, loc_map[decl_name], file_map)

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ It depends on features of Lean 3.5c added in
 ```
 pip install -r requirements.txt
 rm -rf _target
-leanproject get-mathlib-cache
+leanproject up
 ```
 
 Make sure that olean files are generated for mathlib in `_target`, otherwise this will be extremely slow.


### PR DESCRIPTION
The `con` directory can not be created on windows.