### PR TITLE
add action for deploying demo builds on request

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,82 @@
+name: build test site on trigger comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: khan/pull-request-comment-trigger@master
+        id: check
+        with:
+          trigger: '#deploy'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      # this step is needed to get the PR ref from an issue comment
+      # https://github.com/actions/checkout/issues/331
+      - uses: actions/github-script@v3
+        if: steps.check.outputs.triggered == 'true'
+        id: get-pr
+        with:
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            }
+            core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+            try {
+              const result = await github.pulls.get(request)
+              return result.data
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`)
+            }
+      - uses: actions/checkout@v2
+        if: steps.check.outputs.triggered == 'true'
+        with:
+          repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
+          ref: ${{ fromJSON(steps.get-pr.outputs.result).head.sha }} # or .head.ref for branch name
+
+      - name: Checkout mathlib
+        if: steps.check.outputs.triggered == 'true'
+        run: git clone https://github.com/leanprover-community/mathlib
+
+      - name: install elan
+        if: steps.check.outputs.triggered == 'true'
+        run: |
+          set -o pipefail
+          curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
+          cd mathlib
+          ~/.elan/bin/lean --version
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: install Python
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: install Python dependencies
+        if: steps.check.outputs.triggered == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: run leanproject
+        if: steps.check.outputs.triggered == 'true'
+        run: |
+          cd mathlib
+          leanproject up
+
+      - name: generate docs
+        if: steps.check.outputs.triggered == 'true'
+        run: ./deploy_docs.sh "mathlib" ".." "mathlib" "leanprover-community" "mathlib_docs_demo" "true"
+        env:
+          DEPLOY_GITHUB_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
+          github_repo: ${{ github.repository }}
+          github_event: ${{ github.event_name }}
+          github_ref: ${{ github.ref }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -6,20 +6,54 @@ on:
 
 jobs:
   deploy:
+    name: Deploy
     runs-on: ubuntu-latest
+    if: (toJSON(github.event.issue.pull_request) != 'null') && (startsWith(github.event.comment.body, '#deploy') || contains(toJSON(github.event.comment.body), '\r\n#deploy'))
     steps:
-      - uses: khan/pull-request-comment-trigger@master
-        id: check
+      - uses: octokit/request-action@v2.x
+        name: Get PR head
+        id: get_pr_head
         with:
-          trigger: '#deploy'
-          reaction: rocket
+          route: GET /repos/:repository/pulls/:pull_number
+          repository: ${{ github.repository }}
+          pull_number: ${{ github.event.issue.number }}
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Parse steps.get_pr_head.outputs.data, since it is a string
+      - id: parse_pr_head
+        name: Parse PR head
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_pr_head.outputs.data }}
+          head_user: 'head.user.login'
+
+      # we skip the rest if this PR is from a fork,
+      # since the GITHUB_TOKEN doesn't have write perms
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
+        uses: octokit/request-action@v2.x
+        name: Get comment author
+        id: get_user
+        with:
+          route: GET /repos/:repository/collaborators/:username/permission
+          repository: ${{ github.repository }}
+          username: ${{ github.event.comment.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Parse steps.get_user.outputs.data, since it is a string
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
+        id: parse_user
+        name: Parse comment author permission
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_user.outputs.data }}
+          permission: 'permission'
 
       # this step is needed to get the PR ref from an issue comment
       # https://github.com/actions/checkout/issues/331
       - uses: actions/github-script@v3
-        if: steps.check.outputs.triggered == 'true'
+        if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         id: get-pr
         with:
           script: |
@@ -36,17 +70,17 @@ jobs:
               core.setFailed(`Request failed with error ${err}`)
             }
       - uses: actions/checkout@v2
-        if: steps.check.outputs.triggered == 'true'
+        if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         with:
           repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
           ref: ${{ fromJSON(steps.get-pr.outputs.result).head.sha }} # or .head.ref for branch name
 
       - name: Checkout mathlib
-        if: steps.check.outputs.triggered == 'true'
+        if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         run: git clone https://github.com/leanprover-community/mathlib
 
       - name: install elan
-        if: steps.check.outputs.triggered == 'true'
+        if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         run: |
           set -o pipefail
           curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
@@ -55,25 +89,25 @@ jobs:
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
       - name: install Python
-        if: steps.check.outputs.triggered == 'true'
+        if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
 
       - name: install Python dependencies
-        if: steps.check.outputs.triggered == 'true'
+        if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: run leanproject
-        if: steps.check.outputs.triggered == 'true'
+        if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         run: |
           cd mathlib
           leanproject up
 
       - name: generate docs
-        if: steps.check.outputs.triggered == 'true'
+        if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         run: ./deploy_docs.sh "mathlib" ".." "mathlib" "leanprover-community" "mathlib_docs_demo" "true"
         env:
           DEPLOY_GITHUB_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           else
             deploy="false"
           fi
-          ./deploy_docs.sh "mathlib" ".." "mathlib" "leanprover-community" "mathlib_docs" deploy
+          ./deploy_docs.sh "mathlib" ".." "mathlib" "leanprover-community" "mathlib_docs" "$deploy"
         env:
           DEPLOY_GITHUB_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
           github_repo: ${{ github.repository }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,13 @@ jobs:
           leanproject up
 
       - name: generate docs
-        run: ./deploy_docs.sh "mathlib" ".." "mathlib"
+        run: |
+          if [ "$github_repo" = "leanprover-community/doc-gen" ] && [ "$github_ref" = "refs/heads/master" ]; then
+            deploy="true"
+          else
+            deploy="false"
+          fi
+          ./deploy_docs.sh "mathlib" ".." "mathlib" "leanprover-community" "mathlib_docs" deploy
         env:
           DEPLOY_GITHUB_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
           github_repo: ${{ github.repository }}

--- a/deploy_docs.sh
+++ b/deploy_docs.sh
@@ -2,6 +2,10 @@
 # $1 : path to mathlib from working directory (mathlib: ".", doc-gen: "mathlib")
 # $2 : path to doc-gen from mathlib (mathlib: "doc-gen", doc-gen: "..")
 # $3 : path to mathlib from doc-gen (mathlib: "..", doc-gen: "mathlib")
+# $4 : github organization to deploy to
+# $5 : github repo to deploy to
+# $6 : whether to deploy ("true"/"false")
+
 
 DEPLOY_GITHUB_USER=leanprover-community-bot
 
@@ -19,7 +23,7 @@ docgen_git_hash="$(git log -1 --pretty=format:%h)"
 sed -i "s/rev = \"\S*\"/rev = \"$mathlib_git_hash\"/" leanpkg.toml
 echo -e "builtin_path\npath ./src\npath $3/src" > leanpkg.path
 
-git clone "https://$DEPLOY_GITHUB_USER:$DEPLOY_GITHUB_TOKEN@github.com/leanprover-community/mathlib_docs.git"
+git clone "https://$DEPLOY_GITHUB_USER:$DEPLOY_GITHUB_TOKEN@github.com/$4/$5.git" mathlib_docs
 
 # skip if docs for this commit have already been generated
 if [ "$(cd mathlib_docs && git log -1 --pretty=format:%s)" == "automatic update to mathlib $mathlib_short_git_hash using doc-gen $docgen_git_hash" ]; then
@@ -33,10 +37,10 @@ rm -rf mathlib_docs/docs/
 # but this is better than trying to recompile all of mathlib.
 elan override set "$lean_version"
 
-./gen_docs -w 'https://leanprover-community.github.io/mathlib_docs/' \
+./gen_docs -w 'https://$4.github.io/$5/' \
   -r "$3/" -t "mathlib_docs/docs/"
 
-if [ "$github_repo" = "leanprover-community/doc-gen" ] && [ "$github_ref" = "refs/heads/master" ]; then
+if [ "$6" = "true" ]; then
   cd mathlib_docs/docs
   git config user.email "leanprover.community@gmail.com"
   git config user.name "leanprover-community-bot"


### PR DESCRIPTION
I had this idea a while back but was inspired by #110 to actually implement it.

This adds a listener for the token `#deploy` in PR comments. If you make a comment with this token, it will build the docs using the PR source and upload them to a demo repo (fixed to `leanprover-community/mathlib_docs_demo` ~~which I haven't created yet~~).

There's a bunch of duplicated code between this and the action we use now. I'm not really sure how to make this more modular. Also this is only half-tested. Any thoughts?