### PR TITLE
references page and links

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,4 +5,4 @@ lean_version = "leanprover-community/lean:3.26.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "97f89af64791b5149678fae75ca75fc44912da42"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "5b579a2c3c3706e518dae73630c9397a5f7d900f"}

--- a/mistletoe_renderer.py
+++ b/mistletoe_renderer.py
@@ -3,22 +3,46 @@ This module contains a class CustomHTMLRenderer, which uses
 mistletoe to generate HTML from markdown.
 
 Extra features include:
+- Linkifying raw URLs
 - Managing LaTeX so that MathJax will be able to process it in the browser
 - Syntax highlighting with Pygments
 """
 import re
 
-from mistletoe import Document, HTMLRenderer
+from mistletoe import Document, HTMLRenderer, span_token
 from pygments import highlight
 from pygments.lexers import get_lexer_by_name as get_lexer
 from pygments.formatters.html import HtmlFormatter
 
 from mathjax_editing import remove_math, replace_math
 
+class RawUrl(span_token.SpanToken):
+    """
+    Detect raw URLs.
+    """
+    parse_inner = False
+    # regex to extract raw URLs from Markdown from:
+    # https://github.com/trentm/python-markdown2/wiki/link-patterns#converting-links-into-links-automatically
+    pattern = re.compile(
+        r'((([A-Za-z]{3,9}:(?:\/\/)?)'  # scheme
+        r'(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+(:\[0-9]+)?'  # user@hostname:port
+        r'|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)'  # www.|user@hostname
+        r'((?:\/[\+~%\/\.\w\-]*)?'  # path
+        r'\??(?:[\-\+=&;%@\.\w]*)'  # query parameters
+        r'#?(?:[\.\!\/\\\w\-]*))?)'  # fragment
+        r'(?![^<]*?(?:<\/\w+>|\/?>))'  # ignore anchor HTML tags
+        r'(?![^\(]*?\))'  # ignore links in brackets (Markdown links and images)
+    )
+
+    def __init__(self, match):
+        self.url = match.group(1)
+
 class CustomHTMLRenderer(HTMLRenderer):
     """
     The main rendering function is `render_md`.
     """
+    def __init__(self):
+        super().__init__(RawUrl)
 
     def render_md(self, ds):
         """
@@ -84,3 +108,9 @@ class CustomHTMLRenderer(HTMLRenderer):
         except:
             lexer = get_lexer('text')
         return highlight(code, lexer, self.formatter)
+
+    def render_raw_url(self, token):
+        """
+        Linkify raw URLs.
+        """
+        return f'<a href="{token.url}">{token.url}</a>'

--- a/mistletoe_renderer.py
+++ b/mistletoe_renderer.py
@@ -3,42 +3,22 @@ This module contains a class CustomHTMLRenderer, which uses
 mistletoe to generate HTML from markdown.
 
 Extra features include:
-- Library note links
 - Managing LaTeX so that MathJax will be able to process it in the browser
 - Syntax highlighting with Pygments
 """
 import re
 
-from mistletoe import Document, HTMLRenderer, span_token
+from mistletoe import Document, HTMLRenderer
 from pygments import highlight
 from pygments.lexers import get_lexer_by_name as get_lexer
 from pygments.formatters.html import HtmlFormatter
 
 from mathjax_editing import remove_math, replace_math
 
-
-class NoteLink(span_token.SpanToken):
-    """
-    Detect library note links
-    """
-    parse_inner = False
-    pattern = re.compile(r'Note \[(.*)\]', re.I)
-
-    def __init__(self, match):
-        self.body = match.group(0)
-        self.note = match.group(1)
-
-
 class CustomHTMLRenderer(HTMLRenderer):
     """
-    Call the constructor with `site_root`.
-
     The main rendering function is `render_md`.
     """
-
-    def __init__(self, site_root):
-        self.site_root = site_root
-        super().__init__(NoteLink)
 
     def render_md(self, ds):
         """
@@ -104,9 +84,3 @@ class CustomHTMLRenderer(HTMLRenderer):
         except:
             lexer = get_lexer('text')
         return highlight(code, lexer, self.formatter)
-
-    def render_note_link(self, token):
-        """
-        Render library note links
-        """
-        return f'<a href="{self.site_root}notes.html#{token.note}">{token.body}</a>'

--- a/print_docs.py
+++ b/print_docs.py
@@ -356,30 +356,30 @@ def linkify_markdown(string, loc_map):
   def linkify_note(body, note):
     if note in global_notes:
       return f'<a id="{note_backref(note)}" href="{site_root}notes.html#{note}">{body}</a>'
-    return f'{body}'
-  def linkify_named_ref(name, key):
+    return body
+  def linkify_named_ref(body, name, key):
     if key in bib.entries:
       return f'<a id="{bib_backref(key)}" href="{site_root}references.html#{key}">{name}</a>'
-    return f'[{name}][{key}]'
-  def linkify_standalone_ref(key):
+    return body
+  def linkify_standalone_ref(body, key):
     if key in bib.entries:
-      return f'<a id="{bib_backref(key)}" href="{site_root}references.html#{key}">[{key}]</a>'
-    return f'[{key}]'
+      return f'<a id="{bib_backref(key)}" href="{site_root}references.html#{key}">{body}</a>'
+    return body
 
   # notes
   string = re.sub(note_pattern,
-    lambda p: f'{linkify_note(p.group(0), p.group(1))}', string)
+    lambda p: linkify_note(p.group(0), p.group(1)), string)
   # inline declaration names
   string = re.sub(r'<code>([^<]+)</code>',
-    lambda p: '<code>{}</code>'.format(linkify_type(p.group(1))), string)
+    lambda p: f'<code>{linkify_type(p.group(1))}</code>', string)
   # declaration names in highlighted Lean code snippets
   string = re.sub(r'<span class="n">([^<]+)</span>',
-    lambda p: '<span class="n">{}</span>'.format(linkify_type(p.group(1))), string)
+    lambda p: f'<span class="n">{linkify_type(p.group(1))}</span>', string)
   # references (don't match if there are illegal characters for a BibTeX key, cf. https://tex.stackexchange.com/a/408548)
   string = re.sub(r'\[([^\]]+)\]\s*\[([^{ },~#%\\]+)\]',
-    lambda p: f'{linkify_named_ref(p.group(1), p.group(2))}', string)
+    lambda p: linkify_named_ref(p.group(0), p.group(1), p.group(2)), string)
   string = re.sub(r'\[([^{ },~#%\\]+)\]',
-    lambda p: f'{linkify_standalone_ref(p.group(1))}', string)
+    lambda p: linkify_standalone_ref(p.group(0), p.group(1)), string)
   return string
 
 def plaintext_summary(markdown, max_chars = 200):

--- a/print_docs.py
+++ b/print_docs.py
@@ -398,7 +398,8 @@ def linkify_markdown(string: str, loc_map) -> str:
     return body
   def linkify_standalone_ref(body: str, key: str) -> str:
     if key in bib.entries:
-      return f'<a id="{bib_backref(key)}" href="{site_root}references.html#{key}">{body}</a>'
+      alpha_label = bib.entries[key].fields["alpha_label"]
+      return f'<a id="{bib_backref(key)}" href="{site_root}references.html#{alpha_label}">[{alpha_label}]</a>'
     return body
 
   # notes

--- a/print_docs.py
+++ b/print_docs.py
@@ -107,6 +107,7 @@ count = Counter()
 for key, data in bib.entries.items():
   label = data.alpha_label
   # Finalize duplicate labels by appending 'a', 'b', 'c', etc.
+  # Currently the ordering is determined by `docs/references.bib`
   if counted[label] > 1:
     data.alpha_label += chr(ord('a') + count[label])
     count.update([label])

--- a/print_docs.py
+++ b/print_docs.py
@@ -120,6 +120,9 @@ for key, data in bib.entries.items():
     eprint = data.fields['eprint']
     if eprint.startswith('arXiv:'):
       url = 'https://arxiv.org/abs/'+eprint[6:]
+    elif (('archivePrefix' in data.fields and data.fields['archivePrefix'] == 'arXiv') or
+      ('eprinttype' in data.fields and data.fields['eprinttype'] == 'arXiv')):
+      url = 'https://arxiv.org/abs/'+eprint
     else:
       url = eprint
   # else:

--- a/print_docs.py
+++ b/print_docs.py
@@ -333,10 +333,14 @@ def linkify_markdown(string, loc_map):
     splitstr = re.split(r'([\s\[\]\(\)\{\}])', string)
     tks = map(lambda s: linkify(s, loc_map), splitstr)
     return "".join(tks)
-  def linkify_ref(string):
+  def linkify_named_ref(name, string):
+    if string in bib.entries:
+      return f'<a href="{site_root}references.html#{string}">{name}</a>'
+    return f'[{name}][{string}]'
+  def linkify_standalone_ref(string):
     if string in bib.entries:
       return f'<a href="{site_root}references.html#{string}">[{string}]</a>'
-    return string
+    return f'[{string}]'
 
   # inline declaration names
   string = re.sub(r'<code>([^<]+)</code>',
@@ -345,8 +349,10 @@ def linkify_markdown(string, loc_map):
   string = re.sub(r'<span class="n">([^<]+)</span>',
     lambda p: '<span class="n">{}</span>'.format(linkify_type(p.group(1))), string)
   # references (don't match if there are illegal characters for a BibTeX key, cf. https://tex.stackexchange.com/a/408548)
+  string = re.sub(r'\[([^\]]+)\]\[([^{ },~#%\\]+)\]',
+    lambda p: f'{linkify_named_ref(p.group(1), p.group(2))}', string)
   string = re.sub(r'\[([^{ },~#%\\]+)\]',
-    lambda p: f'{linkify_ref(p.group(1))}', string)
+    lambda p: f'{linkify_standalone_ref(p.group(1))}', string)
   return string
 
 def plaintext_summary(markdown, max_chars = 200):

--- a/print_docs.py
+++ b/print_docs.py
@@ -335,7 +335,7 @@ def linkify_markdown(string, loc_map):
     return "".join(tks)
   def linkify_ref(string):
     if string in bib.entries:
-      return f'<a href="{site_root}references.html#{string}">{string}</a>'
+      return f'<a href="{site_root}references.html#{string}">[{string}]</a>'
     return string
 
   # inline declaration names

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,8 @@ mathlibtools
 pygments >= 2.7.1
 jinja2
 networkx
+pybtex>=0.22.2
+latexcodec>=2.0.0
+PyYAML>=5.3.1
+six>=1.15.0
+pylatexenc>=2.4

--- a/style.css
+++ b/style.css
@@ -314,10 +314,23 @@ nav {
 }
 
 /* Make `#id` links appear below header. */
-.decl, h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], a[id], li[id] {
-    scroll-margin-top: var(--header-height);
+.decl::before, h1[id]::before, h2[id]::before, h3[id]::before,
+        h4[id]::before, h5[id]::before, h6[id]::before,
+        a[id]::before, li[id]::before {
+    content: "";
+    display: block;
+    height:      var(--fragment-offset);
+    padding-top:  var(--fragment-offset);
+    margin-top:  calc(-1 * var(--fragment-offset));
+    box-sizing: inherit;
+    visibility: hidden;
 }
-
+/* The following seems like a better solution;
+however, Safari doesn't support it :(
+<https://caniuse.com/mdn-css_properties_scroll-margin-top> */
+/* .decl, h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], a[id], li[id] {
+    scroll-margin-top: var(--fragment-offset);
+} */
 
 /* hide # after markdown headings except on hover */
 .markdown-heading:not(:hover) > .hover-link {

--- a/style.css
+++ b/style.css
@@ -314,23 +314,34 @@ nav {
 }
 
 /* Make `#id` links appear below header. */
-.decl::before, h1[id]::before, h2[id]::before, h3[id]::before,
-        h4[id]::before, h5[id]::before, h6[id]::before,
-        a[id]::before, li[id]::before {
-    content: "";
-    display: block;
-    height:      var(--fragment-offset);
-    padding-top:  var(--fragment-offset);
-    margin-top:  calc(-1 * var(--fragment-offset));
-    box-sizing: inherit;
-    visibility: hidden;
-}
-/* The following seems like a better solution;
-however, Safari doesn't support it :(
-<https://caniuse.com/mdn-css_properties_scroll-margin-top> */
-/* .decl, h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], a[id], li[id] {
+.decl, h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
     scroll-margin-top: var(--fragment-offset);
-} */
+}
+/* don't need as much vertical space for these
+inline elements */
+a[id], li[id] {
+    scroll-margin-top: var(--header-height);
+}
+
+/* HACK: Safari doesn't support scroll-margin-top for
+fragment links (yet?)
+https://caniuse.com/mdn-css_properties_scroll-margin-top
+https://bugs.webkit.org/show_bug.cgi?id=189265
+*/
+@supports not (scroll-margin-top: var(--fragment-offset)) {
+    .decl::before, h1[id]::before, h2[id]::before, h3[id]::before,
+    h4[id]::before, h5[id]::before, h6[id]::before,
+    a[id]::before, li[id]::before {
+        content: "";
+        display: block;
+        height:      var(--fragment-offset);
+        margin-top:  calc(-1 * var(--fragment-offset));
+        box-sizing: inherit;
+        visibility: hidden;
+        width: 1px;
+    }
+}
+
 
 /* hide # after markdown headings except on hover */
 .markdown-heading:not(:hover) > .hover-link {

--- a/style.css
+++ b/style.css
@@ -323,6 +323,10 @@ nav {
     box-sizing: inherit;
     visibility: hidden;
 }
+li[id] {
+    scroll-margin-top: var(--header-height);
+}
+
 
 /* hide # after markdown headings except on hover */
 .markdown-heading:not(:hover) > .hover-link {

--- a/style.css
+++ b/style.css
@@ -314,16 +314,16 @@ nav {
 }
 
 /* Make `#id` links appear below header. */
-.decl::before, h1[id]::before, h2[id]::before, h3[id]::before,
-        h4[id]::before, h5[id]::before, h6[id]::before, a[id]::before {
+/* .decl::before, h1[id]::before, h2[id]::before, h3[id]::before,
+        h4[id]::before, h5[id]::before, h6[id]::before {
     content: "";
     display: block;
     height:      var(--fragment-offset);
     margin-top:  calc(-1 * var(--fragment-offset));
     box-sizing: inherit;
     visibility: hidden;
-}
-li[id] {
+} */
+.decl, h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], a[id], li[id] {
     scroll-margin-top: var(--header-height);
 }
 

--- a/style.css
+++ b/style.css
@@ -314,15 +314,6 @@ nav {
 }
 
 /* Make `#id` links appear below header. */
-/* .decl::before, h1[id]::before, h2[id]::before, h3[id]::before,
-        h4[id]::before, h5[id]::before, h6[id]::before {
-    content: "";
-    display: block;
-    height:      var(--fragment-offset);
-    margin-top:  calc(-1 * var(--fragment-offset));
-    box-sizing: inherit;
-    visibility: hidden;
-} */
 .decl, h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], a[id], li[id] {
     scroll-margin-top: var(--header-height);
 }

--- a/templates/attributes.j2
+++ b/templates/attributes.j2
@@ -3,7 +3,7 @@
 {% block title %}Attributes{% endblock %}
 
 {%- block metadesc -%}
-  {{ "Attributes are a tool for associating information with declarations. 
+  {{ "Attributes are a tool for associating information with declarations.
   In the simplest case, an attribute is a tag that can be applied to a declaration. simp is a common example of this." | plaintext_summary }}
 {%- endblock -%}
 
@@ -29,6 +29,6 @@ attribute [attr_name] decl_name_1 decl_name_2 decl_name 3
 ```
 
 The core API for creating and using attributes can be found in
-[core.init.meta.attribute](core/init/meta/attribute.html).
+[init.meta.attribute](init/meta/attribute.html).
 {% endfilter %}
 {% endblock %}

--- a/templates/navbar.j2
+++ b/templates/navbar.j2
@@ -5,6 +5,7 @@
 <div class="nav_link"><a href="{{site_root}}hole_commands.html">hole commands</a></div>
 <div class="nav_link"><a href="{{site_root}}attributes.html">attributes</a></div>
 <div class="nav_link"><a href="{{site_root}}notes.html">notes</a></div>
+<div class="nav_link"><a href="{{site_root}}references.html">references</a></div>
 
 <h3>Additional documentation</h3>
 {% for (filename, displayname, _, community_site_url) in extra_doc_files %}

--- a/templates/notes.j2
+++ b/templates/notes.j2
@@ -14,10 +14,14 @@
 <p>Various implementation details are noted in the mathlib source, and referenced later on.
 We collect these notes here.</p>
 
-{% for note_name, note_markdown in notes %}
+{% for note_name, note_data in notes %}
     <div class="note">
         <h2 id="{{note_name}}"><a href="#{{note_name}}">{{note_name}}</a></h2>
-        {{ note_markdown | convert_markdown }}
+        {{ note_data['md'] | convert_markdown }}
+
+        referenced by: <small>{% for filename, backref_id in note_data['backrefs'] %}
+        <a href="{{ filename }}#{{ backref_id }}">[{{ loop.index }}]</a>
+      {% endfor %}</small>
     </div>
 {% endfor %}
 {% endblock %}

--- a/templates/notes.j2
+++ b/templates/notes.j2
@@ -19,9 +19,11 @@ We collect these notes here.</p>
         <h2 id="{{note_name}}"><a href="#{{note_name}}">{{note_name}}</a></h2>
         {{ note_data['md'] | convert_markdown }}
 
-        referenced by: <small>{% for filename, backref_id in note_data['backrefs'] %}
-        <a href="{{ filename }}#{{ backref_id }}">[{{ loop.index }}]</a>
-      {% endfor %}</small>
+        {% if note_data['backrefs'] | length > 0 %}
+        referenced by: <small>{% for filename, backref_id, title in note_data['backrefs'] %}
+        <a href="{{ filename }}#{{ backref_id }}" title="{{ title }}">[{{ loop.index }}]</a>
+        {% endfor %}</small>
+        {% endif %}
     </div>
 {% endfor %}
 {% endblock %}

--- a/templates/notes.j2
+++ b/templates/notes.j2
@@ -17,10 +17,10 @@ We collect these notes here.</p>
 {% for note_name, note_data in notes %}
     <div class="note">
         <h2 id="{{note_name}}"><a href="#{{note_name}}">{{note_name}}</a></h2>
-        {{ note_data['md'] | convert_markdown }}
+        {{ note_data.md | convert_markdown }}
 
-        {% if note_data['backrefs'] | length > 0 %}
-        referenced by: <small>{% for filename, backref_id, title in note_data['backrefs'] %}
+        {% if note_data.backrefs | length > 0 %}
+        referenced by: <small>{% for filename, backref_id, title in note_data.backrefs %}
         <a href="{{ filename }}#{{ backref_id }}" title="{{ title }}">[{{ loop.index }}]</a>
         {% endfor %}</small>
         {% endif %}

--- a/templates/references.j2
+++ b/templates/references.j2
@@ -19,7 +19,10 @@
       {% else %}{{ entry.fields['title'] | tex }}.
       {% endif %}
       {% if entry.fields['journal'] %}{{ entry.fields['journal'] | tex }},{% endif %}
-      {{ entry.fields['year'] }}
+      {{ entry.fields['year'] }}.
+      <small>{% for filename, backref_id in entry.fields['backrefs'] %}
+        <a href="{{ filename }}#{{ backref_id }}">[{{ loop.index }}]</a>
+      {% endfor %}</small>
     </li>
 {% endfor %}
 </ul>

--- a/templates/references.j2
+++ b/templates/references.j2
@@ -14,13 +14,13 @@
 
 <ul>
 {% for _, entry in entries %}
-    <li id="{{entry.fields['alpha_label']}}"><a href="#{{entry.fields['alpha_label']}}">[{{entry.fields['alpha_label']}}]</a> {% for author in entry.persons['author'] %}{{ ' '.join(author.first_names).strip('{}') | tex }} {{ ' '.join(author.last_names).strip('{}') | tex}}, {% endfor %}
+    <li id="{{entry.alpha_label}}"><a href="#{{entry.alpha_label}}">[{{entry.alpha_label}}]</a> {% for author in entry.persons['author'] %}{{ ' '.join(author.first_names).strip('{}') | tex }} {{ ' '.join(author.last_names).strip('{}') | tex}}, {% endfor %}
       {% if entry.fields['url'] %}<a href="{{ entry.fields['url'] }}">{{ entry.fields['title'] | tex }}</a>.
       {% else %}{{ entry.fields['title'] | tex }}.
       {% endif %}
       {% if entry.fields['journal'] %}{{ entry.fields['journal'] | tex }},{% endif %}
       {{ entry.fields['year'] }}.
-      <small>{% for filename, backref_id, title in entry.fields['backrefs'] %}
+      <small>{% for filename, backref_id, title in entry.backrefs %}
         <a href="{{ filename }}#{{ backref_id }}" title="{{ title }}">[{{ loop.index }}]</a>
       {% endfor %}</small>
     </li>
@@ -31,7 +31,7 @@
 {% block internal_nav %}
 <h3><a href="#top">References</a></h3>
 {% for _, entry in entries %}
-    <div class="nav_link"><a href="#{{entry.fields['alpha_label']}}">{{entry.fields['alpha_label']}}</a></div>
+    <div class="nav_link"><a href="#{{entry.alpha_label}}">{{entry.alpha_label}}</a></div>
 {% endfor %}
 
 </div>

--- a/templates/references.j2
+++ b/templates/references.j2
@@ -1,0 +1,35 @@
+{% extends "base.j2" %}
+{% block title %}references{% endblock %}
+
+{%- block metadesc -%}
+  {{ "Works referenced in mathlib doc strings are listed on this page." | plaintext_summary }}
+{%- endblock -%}
+
+{% block content %}
+<div class="docfile">
+
+<h1>References</h1>
+
+<p>Works cited in mathlib are collected on this page. This is generated from the BibTeX file <a href="references.bib">docs/references.bib</a>.</p>
+
+<ul>
+{% for key, entry in entries %}
+    <li id="{{key}}"><a href="#{{key}}">[{{key}}]</a> {% for author in entry.persons['author'] %}{{ ' '.join(author.first_names).strip('{}') | tex }} {{ ' '.join(author.last_names).strip('{}') | tex}}, {% endfor %}
+      {% if entry.fields['url'] %}<a href="{{ entry.fields['url'] }}">{{ entry.fields['title'] | tex }}</a>.
+      {% else %}{{ entry.fields['title'] | tex }}.
+      {% endif %}
+      {% if entry.fields['journal'] %}{{ entry.fields['journal'] | tex }},{% endif %}
+      {{ entry.fields['year'] }}
+    </li>
+{% endfor %}
+</ul>
+{% endblock %}
+
+{% block internal_nav %}
+<h3><a href="#top">References</a></h3>
+{% for key, _ in entries %}
+    <div class="nav_link"><a href="#{{key}}">{{key}}</a></div>
+{% endfor %}
+
+</div>
+{% endblock %}

--- a/templates/references.j2
+++ b/templates/references.j2
@@ -10,7 +10,7 @@
 
 <h1>References</h1>
 
-<p>Works cited in mathlib are collected on this page. This is generated from the BibTeX file <a href="references.bib">docs/references.bib</a>.</p>
+<p>Works cited in mathlib are collected on this page. This is generated from the BibTeX file <a href="references.bib">docs/references.bib</a> (<a href="https://github.com/leanprover-community/mathlib/blob/master/docs/references.bib">view on GitHub</a>).</p>
 
 <ul>
 {% for key, entry in entries %}

--- a/templates/references.j2
+++ b/templates/references.j2
@@ -13,8 +13,8 @@
 <p>Works cited in mathlib are collected on this page. This is generated from the BibTeX file <a href="references.bib">docs/references.bib</a> (<a href="https://github.com/leanprover-community/mathlib/blob/master/docs/references.bib">view on GitHub</a>).</p>
 
 <ul>
-{% for key, entry in entries %}
-    <li id="{{key}}"><a href="#{{key}}">[{{key}}]</a> {% for author in entry.persons['author'] %}{{ ' '.join(author.first_names).strip('{}') | tex }} {{ ' '.join(author.last_names).strip('{}') | tex}}, {% endfor %}
+{% for _, entry in entries %}
+    <li id="{{entry.fields['alpha_label']}}"><a href="#{{entry.fields['alpha_label']}}">[{{entry.fields['alpha_label']}}]</a> {% for author in entry.persons['author'] %}{{ ' '.join(author.first_names).strip('{}') | tex }} {{ ' '.join(author.last_names).strip('{}') | tex}}, {% endfor %}
       {% if entry.fields['url'] %}<a href="{{ entry.fields['url'] }}">{{ entry.fields['title'] | tex }}</a>.
       {% else %}{{ entry.fields['title'] | tex }}.
       {% endif %}
@@ -30,8 +30,8 @@
 
 {% block internal_nav %}
 <h3><a href="#top">References</a></h3>
-{% for key, _ in entries %}
-    <div class="nav_link"><a href="#{{key}}">{{key}}</a></div>
+{% for _, entry in entries %}
+    <div class="nav_link"><a href="#{{entry.fields['alpha_label']}}">{{entry.fields['alpha_label']}}</a></div>
 {% endfor %}
 
 </div>

--- a/templates/references.j2
+++ b/templates/references.j2
@@ -20,8 +20,8 @@
       {% endif %}
       {% if entry.fields['journal'] %}{{ entry.fields['journal'] | tex }},{% endif %}
       {{ entry.fields['year'] }}.
-      <small>{% for filename, backref_id in entry.fields['backrefs'] %}
-        <a href="{{ filename }}#{{ backref_id }}">[{{ loop.index }}]</a>
+      <small>{% for filename, backref_id, title in entry.fields['backrefs'] %}
+        <a href="{{ filename }}#{{ backref_id }}" title="{{ title }}">[{{ loop.index }}]</a>
       {% endfor %}</small>
     </li>
 {% endfor %}


### PR DESCRIPTION
Adds a `references.html` page, generated from mathlib's `docs/references.bib` and creates links from all strings of the form "[bib_entry_key]" in docstrings to the entry on that page. The keys are replaced with auto-generated labels following [the BibTeX "alpha" style](https://www.bibtex.com/s/bibliography-style-base-alpha/).

Also includes backrefs for both bib entries and library notes (links back from the bib / note entries to the pages that cite them). Some of the entries without backrefs correspond to links in `archive/` (e.g. `Hofstadter-1979`) and some are truly missing (e.g. `joyal1977`, there's a `joyal1997` in `set_theory.pgame` which is probably a typo).

Finally, I added functionality that turns raw URLs in the markdown into links.

I did basically the bare minimum, copying as much as I could from leanprover-community.github.io, so any styling / formatting suggestions are welcome!

<img width="1229" alt="Screen Shot 2021-02-20 at 12 11 41 AM" src="https://user-images.githubusercontent.com/5209952/108584545-3f15db00-7310-11eb-8514-064197d33bf1.png">

[Zulip thread here](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/https.3A.2F.2Fleanprover-community.2Egithub.2Eio.2Fmathlib_docs.2F/near/226893761).