### PR TITLE
parallelize json export

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "."
 version = "0.1"
-lean_version = "leanprover-community/lean:3.26.0"
+lean_version = "leanprover-community/lean:3.27.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "5b579a2c3c3706e518dae73630c9397a5f7d900f"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "97d13d7561ef9c9a21587cf62324f8b2d215a7f8"}

--- a/src/export_json.lean
+++ b/src/export_json.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Robert Y. Lewis
 -/
 
-import tactic.core system.io data.string.defs tactic.interactive data.list.sort data.list.defs
+import tactic.core system.io data.string.defs tactic.interactive data.list.sort
 
 /-!
 Used to generate a json file for html docs.

--- a/src/export_json.lean
+++ b/src/export_json.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Robert Y. Lewis
 -/
 
-import tactic.core system.io data.string.defs tactic.interactive data.list.sort
+import tactic.core system.io data.string.defs tactic.interactive data.list.sort data.list.defs
 
 /-!
 Used to generate a json file for html docs.
@@ -362,15 +362,12 @@ do l ← list.map tactic_doc_entry.add_import <$> get_tactic_doc_entries,
 
 meta def mk_export_json : tactic json := do
 e ← get_env,
-/- Using `environment.mfold` is much cleaner. Unfortunately this led to a segfault, I think because
-of a stack overflow. Converting the environment to a list of declarations and folding over that led
-to "deep recursion detected". -/
 s ← read,
-let decls := e.fold ([] : list json) (λ decl acc,
-  match (enable_links *> process_decl decl) s with
-  | result.success (some di) _ := di.to_json :: acc
-  | _:= acc
-  end),
+let decls := list.reduce_option $ e.get_decls.map_async_chunked $ λ decl,
+match (enable_links *> process_decl decl) s with
+| result.success (some di) _ := some di.to_json
+| _:= none
+end,
 mod_docs ← write_olean_docs,
 notes ← format_notes,
 tactic_docs ← format_tactic_docs,


### PR DESCRIPTION
This is much faster (obviously) and uses less memory (surprisingly).

Thanks to @gebner for https://github.com/leanprover-community/mathlib/pull/6293