### PR TITLE
don't embed commit SHA in as many files

### DIFF
--- a/nav.js
+++ b/nav.js
@@ -101,6 +101,8 @@ if (tse != null) {
 
 
 
+
+
 // Simple declaration search
 // -------------------------
 
@@ -215,4 +217,23 @@ if (howabout) {
           a.appendChild(document.createElement('code')).innerText = decl;
       }
   });
+}
+
+
+
+
+
+
+// Rewrite GitHub links
+// --------------------
+
+for (const elem of document.getElementsByClassName('gh_link')) {
+  const a = elem.firstElementChild;
+  // commit is set in add_commit.js
+  for (const [prefix, replacement] of commit) {
+    if (a.href.startsWith(prefix)) {
+      a.href = a.href.replace(prefix, replacement);
+      break;
+    }
+  }
 }

--- a/print_docs.py
+++ b/print_docs.py
@@ -640,7 +640,7 @@ def write_src_redirect(decl_name, decl_loc, file_map):
   with open_outfile(f'find/{decl_name}/src/index.html') as out:
     out.write(f"""<script src="{site_root}add_commit.js"></script>
 <script>redirectTo("{url}");</script>
-<meta http-equiv="refresh" content="0;url={url}">
+<noscript><a href="{url}">{decl_name} source</a></noscript>
 """)
 
 def write_add_commit_js(url_rewrites: List):

--- a/print_docs.py
+++ b/print_docs.py
@@ -168,28 +168,6 @@ url_rewrites.append([mathlib_github_src_root, mathlib_github_src_root_with_commi
 lean_commit = subprocess.check_output(['lean', '--run', 'src/lean_commit.lean']).decode()
 lean_root = f'https://github.com/leanprover-community/lean/blob/{lean_commit}/library/'
 
-def modify_nav_js(url_rewrites: List):
-  """
-  Adds code to nav.js which rewrites the href attributes of the child
-  <a> element inside every <div> with class "gh_link".
-  """
-  with open_outfile('nav.js', 'a') as out:
-    out.write(f"const commit = {json.dumps(url_rewrites)};")
-    out.write("""
-// Rewrite GitHub links
-// --------------------
-
-for (const elem of document.getElementsByClassName('gh_link')) {
-  const a = elem.firstElementChild;
-  for (const [prefix, replacement] of commit) {
-    if (a.href.startsWith(prefix)) {
-      a.href = a.href.replace(prefix, replacement);
-      break;
-    }
-  }
-}
-""")
-
 def get_name_from_leanpkg_path(p: Path) -> str:
   """ get the package name corresponding to a source path """
   # lean core?
@@ -662,7 +640,7 @@ def write_src_redirect(decl_name, decl_loc, file_map):
   with open_outfile(f'find/{decl_name}/src/index.html') as out:
     out.write(f"""<script src="{site_root}add_commit.js"></script>
 <script>redirectTo("{url}");</script>
-<noscript><meta http-equiv="refresh" content="0;url={url}"></noscript>
+<meta http-equiv="refresh" content="0;url={url}">
 """)
 
 def write_add_commit_js(url_rewrites: List):
@@ -707,8 +685,7 @@ def copy_css_and_js(path, use_symlinks):
 
   cp('style.css', path+'style.css')
   cp('pygments.css', path+'pygments.css')
-  shutil.copyfile('nav.js', path+'nav.js')
-  modify_nav_js(url_rewrites) # must be run *after* nav.js is copied
+  cp('nav.js', path+'nav.js')
   cp('searchWorker.js', path+'searchWorker.js')
   write_add_commit_js(url_rewrites)
 

--- a/templates/base.j2
+++ b/templates/base.j2
@@ -75,6 +75,7 @@ MathJax = {
 
 siteRoot = "{{ site_root }}";
 </script>
+<script src="{{ site_root }}add_commit.js"></script>
 <script src="{{ site_root }}nav.js"></script>
 <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>


### PR DESCRIPTION
This PR is intended to solve problems we've had with the `mathlib_docs` repo. Previously, every update of the docs led to tens of thousands of new blobs being created, because the commit SHA was embedded in every doc page and in every src redirect page.

I made the following changes:
- [x] source links in the HTML files of the doc pages now link to `master`, and `nav.js` rewrites the URLs to point to the precise commit when the page loads. To test: [visit any doc page](https://leanprover-community.github.io/mathlib_docs_demo/meta/expr.html) and click a "source" link; it should take you to the right place on GitHub. It may be worth testing both pages in mathlib and in core Lean since GitHub links for the latter aren't rewritten.
- [x] the src redirect pages now do not contain the commit SHA; a separate `add_commit.js` file performs the redirect. To test: try [this src link for `dvd_sub_pow_of_dvd_sub`](https://leanprover-community.github.io/mathlib_docs_demo/find/dvd_sub_pow_of_dvd_sub/src) (in mathlib, requires a rewrite) and [this src link for `nat`](https://leanprover-community.github.io/mathlib_docs_demo/find/nat/src) (in core Lean, no rewrite required).