### PR TITLE
README: clarify line about .olean files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,8 @@ rm -rf _target
 leanproject up
 ```
 
-Make sure that olean files are generated for mathlib in `_target`, otherwise this will be extremely slow.
+Make sure that [`.olean` files](https://github.com/leanprover/tutorial/blob/master/05_Interacting_with_Lean.org#projects)
+are generated for mathlib in `_target`, otherwise this will be extremely slow.
 
 ## Usage
 


### PR DESCRIPTION
Just a small tweak to make the line less cryptic for beginners.

Although, to be honest I still don't fully understand what this sentence is saying — _how_ does one make sure the `.olean` files are generated in the `_target` folder, and what exactly will be extremely slow otherwise?