### PR TITLE
Output a gexf file for exploring the import graph

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,3 @@ jobs:
         uses: actions/upload-artifact@v2.2.4
         with:
           path: export.json
-
-      - name: Upload import.gexf
-        uses: actions/upload-artifact@v2.2.4
-        with:
-          path: mathlib_docs/docs/import.gexf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,3 +57,8 @@ jobs:
         uses: actions/upload-artifact@v2.2.4
         with:
           path: export.json
+
+      - name: Upload import.gexf
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          path: mathlib_docs/docs/import.gexf

--- a/print_docs.py
+++ b/print_docs.py
@@ -709,7 +709,7 @@ def write_decl_txt(loc_map):
 def write_import_gexf():
   import_graph = env.globals['import_graph']
   with open_outfile('import.gexf') as out:
-    nx.write_gexf(import_graph, out)
+    nx.write_gexf(import_graph, out, encoding="unicode")
 
 def mk_export_map_entry(decl_name, filename, kind, is_meta, line, args, tp):
   return {'filename': str(filename.raw_path),

--- a/print_docs.py
+++ b/print_docs.py
@@ -221,7 +221,7 @@ class ImportName(NamedTuple):
     return '.'.join(self.parts)
 
   def __str__(self):
-    return f'{self.proj}:{self.name}'  # primarily for networkx export
+    return f'{self.project}:{self.name}'  # primarily for networkx export
 
   @property
   def url(self):

--- a/print_docs.py
+++ b/print_docs.py
@@ -220,6 +220,9 @@ class ImportName(NamedTuple):
   def name(self):
     return '.'.join(self.parts)
 
+  def __str__(self):
+    return f'{self.proj}:{self.name}'  # primarily for networkx export
+
   @property
   def url(self):
     return '/'.join(self.parts) + '.html'
@@ -706,11 +709,10 @@ def write_decl_txt(loc_map):
   with open_outfile('decl.bmp') as out:
     out.write('\n'.join(loc_map.keys()))
 
-def write_import_gexf():
-  import_graph = env.globals['import_graph']
-  # stringify the node labels
-  renamings = {import_name: f'{import_name.project}:{import_name.name}' for import_name in import_graph.nodes()}
-  import_graph = nx.relabel_nodes(import_graph, renamings)
+def write_import_gexf(file_map):
+  import_graph = env.globals['import_graph'].copy()
+  for node in import_graph.nodes():
+    node['decl_count'] = len(file_map[node])
 
   with open_outfile('import.gexf') as out:
     nx.write_gexf(import_graph, out, encoding="unicode")
@@ -746,7 +748,7 @@ def main():
   bib = parse_bib_file(f'{local_lean_root}docs/references.bib')
   file_map, loc_map, notes, mod_docs, instances, tactic_docs = load_json()
   setup_jinja_globals(file_map, loc_map, instances, bib)
-  write_import_gexf()
+  write_import_gexf(file_map)
   write_decl_txt(loc_map)
   write_html_files(file_map, loc_map, notes, mod_docs, instances, tactic_docs, bib)
   write_redirects(loc_map, file_map)

--- a/print_docs.py
+++ b/print_docs.py
@@ -709,7 +709,7 @@ def write_decl_txt(loc_map):
 def write_import_gexf():
   import_graph = env.globals['import_graph']
   # stringify the node labels
-  renamings = {import_name : f'{import_name.project}:{import_name.name}' import_name, n_data in import_graph.nodes()}
+  renamings = {import_name: f'{import_name.project}:{import_name.name}' for import_name in import_graph.nodes()}
   import_graph = nx.relabel_nodes(import_graph, renamings}
 
   with open_outfile('import.gexf') as out:

--- a/print_docs.py
+++ b/print_docs.py
@@ -712,7 +712,7 @@ def write_decl_txt(loc_map):
 def write_import_gexf(file_map):
   import_graph = env.globals['import_graph'].copy()
   for node in import_graph.nodes():
-    node['decl_count'] = len(file_map[node])
+    import_graph.nodes[node]['decl_count'] = len(file_map[node])
 
   with open_outfile('import.gexf') as out:
     nx.write_gexf(import_graph, out, encoding="unicode")

--- a/print_docs.py
+++ b/print_docs.py
@@ -710,7 +710,7 @@ def write_import_gexf():
   import_graph = env.globals['import_graph']
   # stringify the node labels
   renamings = {import_name: f'{import_name.project}:{import_name.name}' for import_name in import_graph.nodes()}
-  import_graph = nx.relabel_nodes(import_graph, renamings}
+  import_graph = nx.relabel_nodes(import_graph, renamings)
 
   with open_outfile('import.gexf') as out:
     nx.write_gexf(import_graph, out, encoding="unicode")

--- a/print_docs.py
+++ b/print_docs.py
@@ -706,6 +706,11 @@ def write_decl_txt(loc_map):
   with open_outfile('decl.bmp') as out:
     out.write('\n'.join(loc_map.keys()))
 
+def write_import_gexf():
+  import_graph = env.globals['import_graph']
+  with open_outfile('import.gexf') as out:
+    nx.write_gexf(import_graph, out)
+
 def mk_export_map_entry(decl_name, filename, kind, is_meta, line, args, tp):
   return {'filename': str(filename.raw_path),
           'kind': kind,
@@ -737,6 +742,7 @@ def main():
   bib = parse_bib_file(f'{local_lean_root}docs/references.bib')
   file_map, loc_map, notes, mod_docs, instances, tactic_docs = load_json()
   setup_jinja_globals(file_map, loc_map, instances, bib)
+  write_import_gexf()
   write_decl_txt(loc_map)
   write_html_files(file_map, loc_map, notes, mod_docs, instances, tactic_docs, bib)
   write_redirects(loc_map, file_map)

--- a/print_docs.py
+++ b/print_docs.py
@@ -708,6 +708,10 @@ def write_decl_txt(loc_map):
 
 def write_import_gexf():
   import_graph = env.globals['import_graph']
+  # stringify the node labels
+  renamings = {import_name : f'{import_name.project}:{import_name.name}' import_name, n_data in import_graph.nodes()}
+  import_graph = nx.relabel_nodes(import_graph, renamings}
+
   with open_outfile('import.gexf') as out:
     nx.write_gexf(import_graph, out, encoding="unicode")
 


### PR DESCRIPTION
This is much much smaller than the export.json, but has plenty of information in to produce graphs from.

https://eric-wieser.github.io/doc-gen/import-graph.html makes use of this file. Given the dependencies of the graph, it might make sense not to host the actual visualizer within the doc-gen part of the mathlib docs.