### PR TITLE
Add a link to the import graph viewer

### DIFF
--- a/templates/imports.j2
+++ b/templates/imports.j2
@@ -17,4 +17,6 @@
         {% endfor -%}
         </ul>
     </details>
+    <a href="https://eric-wieser.github.io/mathlib-import-graph/?highlight={{filename}}&docs_url={{site_root}}">
+        Interactive graph</a>
 </div>


### PR DESCRIPTION
Example:

https://eric-wieser.github.io/mathlib-import-graph/?highlight=core:data.dlist&docs_url=https://leanprover-community.github.io/mathlib_docs/