### PR TITLE
Do not use localized notation for pi and mu

### DIFF
--- a/src/export_json.lean
+++ b/src/export_json.lean
@@ -406,7 +406,7 @@ do m ← of_tactic localized_attr.get_cache,
    cmds ← of_tactic $ get_localized m.keys,
    cmds.mmap' $ λ m,
     when (¬ ∃ tok ∈ m.split_on '`', by exact
-        (tok.length = 1 ∧ tok.front.is_alphanum) ∨ tok ∈ ["ε", "φ", "ψ", "W_", "σ", "ζ"]) $
+        (tok.length = 1 ∧ tok.front.is_alphanum) ∨ tok ∈ ["ε", "φ", "ψ", "W_", "σ", "ζ", "μ", "π"]) $
     lean.parser.emit_code_here m <|> skip
 
 meta def main : io unit := do


### PR DESCRIPTION
In mathlib these are used for real.pi and https://leanprover-community.github.io/mathlib_docs/number_theory/arithmetic_function.html#nat.arithmetic_function.moebius.
But there are far more uses of these symbols for general variable names than there are for these particular meanings.
Removing these should make whole files like https://leanprover-community.github.io/mathlib_docs/measure_theory/measure/measure_space.html#measure_theory.is_probability_measure which use mu on almost every line look a lot nicer