### PR TITLE
Add opengraph tags to `/find/` urls

### DIFF
--- a/print_docs.py
+++ b/print_docs.py
@@ -665,9 +665,8 @@ def write_site_map(partition):
       out.write(site_root + filename + '.html\n')
 
 def write_docs_redirect(decl_name, decl_loc):
-  url = site_root + decl_loc.url
   with open_outfile(f'find/{decl_name}/index.html') as out:
-    out.write(f'<meta http-equiv="refresh" content="0;url={url}#{quote(decl_name)}">')
+    out.write(env.get_template('find.j2').render(decl_name=decl_name, decl_loc=decl_loc))
 
 def write_src_redirect(decl_name, decl_loc, file_map):
   url = library_link_from_decl_name(decl_name, decl_loc, file_map)

--- a/print_docs.py
+++ b/print_docs.py
@@ -664,9 +664,10 @@ def write_site_map(partition):
     for (filename, _, _, _) in extra_doc_files:
       out.write(site_root + filename + '.html\n')
 
-def write_docs_redirect(decl_name, decl_loc):
+def write_docs_redirect(decl_name, decl_loc, file_map):
+  decl = next((d for d in file_map[decl_loc] if d['name'] == decl_name), None)
   with open_outfile(f'find/{decl_name}/index.html') as out:
-    out.write(env.get_template('find.j2').render(decl_name=decl_name, decl_loc=decl_loc))
+    out.write(env.get_template('find.j2').render(decl_name=decl_name, decl_loc=decl_loc, decl=decl)
 
 def write_src_redirect(decl_name, decl_loc, file_map):
   url = library_link_from_decl_name(decl_name, decl_loc, file_map)
@@ -700,7 +701,7 @@ def write_redirects(loc_map, file_map):
   for decl_name in loc_map:
     if (decl_name == 'con' or decl_name.startswith('con.')) and sys.platform == 'win32':
       continue  # can't write these files on windows
-    write_docs_redirect(decl_name, loc_map[decl_name])
+    write_docs_redirect(decl_name, loc_map[decl_name], file_map)
     write_src_redirect(decl_name, loc_map[decl_name], file_map)
 
 def copy_css_and_js(path, use_symlinks):

--- a/print_docs.py
+++ b/print_docs.py
@@ -667,7 +667,7 @@ def write_site_map(partition):
 def write_docs_redirect(decl_name, decl_loc, file_map):
   decl = next((d for d in file_map[decl_loc] if d['name'] == decl_name), None)
   with open_outfile(f'find/{decl_name}/index.html') as out:
-    out.write(env.get_template('find.j2').render(decl_name=decl_name, decl_loc=decl_loc, decl=decl)
+    out.write(env.get_template('find.j2').render(decl_name=decl_name, decl_loc=decl_loc, decl=decl))
 
 def write_src_redirect(decl_name, decl_loc, file_map):
   url = library_link_from_decl_name(decl_name, decl_loc, file_map)

--- a/templates/base.j2
+++ b/templates/base.j2
@@ -12,15 +12,11 @@
     {% if canonical_url is not none %}
     <link rel="canonical" href="{{ canonical_url }}" />
     {% endif %}
-    <meta name="og:title" content="{{ self.title() }} - mathlib docs">
-    <meta name="og:site_name" content="mathlib for Lean - API documentation">
-    <meta name="og:description" content="{{ self.metadesc() }}">
-    <meta name="og:image" content="{{ site_root }}meta-og.png">
-
+    <meta property="og:title" content="{{ self.title() }} - mathlib docs">
+    <meta property="og:site_name" content="mathlib for Lean - API documentation">
+    <meta property="og:description" content="{{ self.metadesc() }}">
+    <meta property="og:image" content="{{ site_root }}meta-og.png">
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ self.title() }} - mathlib docs">
-    <meta name="twitter:description" content="{{ self.metadesc() }}">
-    <meta name="twitter:image" content="{{ site_root }}meta-twitter.png">
     <script src="{{ site_root }}color_scheme.js"></script>
 </head>
 

--- a/templates/find.j2
+++ b/templates/find.j2
@@ -1,5 +1,5 @@
 <meta http-equiv="refresh" content="0;url={{site_root}}{{decl_loc.url}}#{{decl_name | urlencode}}">
-<meta property="og:url" content="0;url={{site_root}}find/{{decl_name | urlencode}}">
+<meta property="og:url" content="{{site_root}}find/{{decl_name | urlencode}}">
 <meta property="og:title" content="{{decl_name}} - mathlib docs">
 <meta property="og:site_name" content="mathlib for Lean - API documentation">
 <meta property="og:description" content="{{ decl.doc_string | default("") | plaintext_summary }}">

--- a/templates/find.j2
+++ b/templates/find.j2
@@ -1,4 +1,5 @@
 <meta http-equiv="refresh" content="0;url={{site_root}}{{decl_loc.url}}#{{decl_name | urlencode}}">
+<meta property="og:url" content="0;url={{site_root}}find/{{decl_name | urlencode}}">
 <meta property="og:title" content="{{decl_name}} - mathlib docs">
 <meta property="og:site_name" content="mathlib for Lean - API documentation">
 <meta property="og:description" content="{{ decl.doc_string | default("") | plaintext_summary }}">

--- a/templates/find.j2
+++ b/templates/find.j2
@@ -1,9 +1,9 @@
 <meta http-equiv="refresh" content="0;url={{site_root}}{{decl_loc.url}}#{{decl_name | urlencode}}">
 <meta name="og:title" content="{{decl_name}} - mathlib docs">
 <meta name="og:site_name" content="mathlib for Lean - API documentation">
-<meta name="og:description" content="{{ decl.doc_string | plaintext_summary }}">
+<meta name="og:description" content="{{ decl.doc_string | default("") | plaintext_summary }}">
 <meta name="og:image" content="https://leanprover-community.github.io/mathlib_docs/meta-og.png">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="{{decl_name}} - mathlib docs">
-<meta name="twitter:description" content="{{ decl.doc_string | plaintext_summary }}">
+<meta name="twitter:description" content="{{ decl.doc_string | default("") | plaintext_summary }}">
 <meta name="twitter:image" content="https://leanprover-community.github.io/mathlib_docs/meta-twitter.png">

--- a/templates/find.j2
+++ b/templates/find.j2
@@ -1,9 +1,6 @@
 <meta http-equiv="refresh" content="0;url={{site_root}}{{decl_loc.url}}#{{decl_name | urlencode}}">
-<meta name="og:title" content="{{decl_name}} - mathlib docs">
-<meta name="og:site_name" content="mathlib for Lean - API documentation">
-<meta name="og:description" content="{{ decl.doc_string | default("") | plaintext_summary }}">
-<meta name="og:image" content="https://leanprover-community.github.io/mathlib_docs/meta-og.png">
+<meta property="og:title" content="{{decl_name}} - mathlib docs">
+<meta property="og:site_name" content="mathlib for Lean - API documentation">
+<meta property="og:description" content="{{ decl.doc_string | default("") | plaintext_summary }}">
+<meta property="og:image" content="https://leanprover-community.github.io/mathlib_docs/meta-og.png">
 <meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="{{decl_name}} - mathlib docs">
-<meta name="twitter:description" content="{{ decl.doc_string | default("") | plaintext_summary }}">
-<meta name="twitter:image" content="https://leanprover-community.github.io/mathlib_docs/meta-twitter.png">

--- a/templates/find.j2
+++ b/templates/find.j2
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;url={{site_root}}{{decl_loc.url}}#{{decl_name | urlencode}}">

--- a/templates/find.j2
+++ b/templates/find.j2
@@ -1,1 +1,9 @@
 <meta http-equiv="refresh" content="0;url={{site_root}}{{decl_loc.url}}#{{decl_name | urlencode}}">
+<meta name="og:title" content="{{decl_name}} - mathlib docs">
+<meta name="og:site_name" content="mathlib for Lean - API documentation">
+<meta name="og:description" content="Documentation for {{decl_name}}">
+<meta name="og:image" content="https://leanprover-community.github.io/mathlib_docs/meta-og.png">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="{{decl_name}} - mathlib docs">
+<meta name="twitter:description" content="Documentation for {{decl_name}}">
+<meta name="twitter:image" content="https://leanprover-community.github.io/mathlib_docs/meta-twitter.png">

--- a/templates/find.j2
+++ b/templates/find.j2
@@ -1,9 +1,9 @@
 <meta http-equiv="refresh" content="0;url={{site_root}}{{decl_loc.url}}#{{decl_name | urlencode}}">
 <meta name="og:title" content="{{decl_name}} - mathlib docs">
 <meta name="og:site_name" content="mathlib for Lean - API documentation">
-<meta name="og:description" content="Documentation for {{decl_name}}">
+<meta name="og:description" content="{{ decl.doc_string | plaintext_summary }}">
 <meta name="og:image" content="https://leanprover-community.github.io/mathlib_docs/meta-og.png">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="{{decl_name}} - mathlib docs">
-<meta name="twitter:description" content="Documentation for {{decl_name}}">
+<meta name="twitter:description" content="{{ decl.doc_string | plaintext_summary }}">
 <meta name="twitter:image" content="https://leanprover-community.github.io/mathlib_docs/meta-twitter.png">


### PR DESCRIPTION
The idea here is to be able to share a `find`-style URL as generated by zulip, and have it show a social preview.

This also corrects the wonky existing meta tags; the `og:*` fields belong in `property` not `name`, and twitter says [we do not need the twitter ones too](https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started) once we have those correct.

Demonstration of this working:

https://www.opengraph.xyz/url/https%3A%2F%2Fleanprover-community.github.io%2Fmathlib_docs_demo%2Ffind%2Falgebra%2F/

https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fleanprover-community.github.io%2Fmathlib_docs_demo%2Ffind%2Falgebra

Note we can't test with https://cards-dev.twitter.com/validator, as `robots.txt` blacklists the doc demo site.