### PR TITLE
Show instances available for a given type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: run tests
+        # note this runs tests against the pinned copy of mathlib, to make them less likely to break
+        # the cronjob build.
+        run: |
+          leanproject get-mathlib-cache
+          lean --make test
+
       - name: run leanproject
         run: |
           cd mathlib

--- a/gen_docs
+++ b/gen_docs
@@ -33,7 +33,7 @@ if [ "$link" -eq "1" ]; then
 fi
 
 bash "$source"scripts/mk_all.sh
-lean src/entrypoint.lean >export.json
+lean --run src/entrypoint.lean >export.json
 bash "$source"scripts/rm_all.sh
 
 python3 print_docs.py -r "$source" -w "$site_root" "${args[@]}"

--- a/print_docs.py
+++ b/print_docs.py
@@ -359,7 +359,7 @@ def load_json():
       continue  # this is doc-gen itself
     file_map[i_name]
 
-  return file_map, loc_map, decls['notes'], mod_docs, decls['instances'], decls['tactic_docs']
+  return file_map, loc_map, decls['notes'], mod_docs, decls['instances'], decls['instances_for'], decls['tactic_docs']
 
 def linkify_core(decl_name, text, loc_map):
   if decl_name in loc_map:
@@ -561,10 +561,11 @@ def mk_site_tree_core(filenames, path=[]):
 
   return entries
 
-def setup_jinja_globals(file_map, loc_map, instances, bib):
+def setup_jinja_globals(file_map, loc_map, instances, instances_for, bib):
   env.globals['import_graph'] = trace_deps(file_map)
   env.globals['site_tree'] = mk_site_tree(file_map)
   env.globals['instances'] = instances
+  env.globals['instances_for'] = instances_for
   env.globals['import_options'] = lambda d, i: import_options(loc_map, d, i)
   env.filters['linkify'] = lambda x: linkify(x, loc_map)
   env.filters['linkify_efmt'] = lambda x: linkify_efmt(x, loc_map)
@@ -579,7 +580,7 @@ current_filename: Optional[str] = None
 current_project: Optional[str] = None
 global_notes = {}
 GlobalNote = namedtuple('GlobalNote', ['md', 'backrefs'])
-def write_html_files(partition, loc_map, notes, mod_docs, instances, tactic_docs, bib):
+def write_html_files(partition, loc_map, notes, mod_docs, instances, instances_for, tactic_docs, bib):
   global current_filename, current_project
   for note_name, note_markdown in notes:
     global_notes[note_name] = GlobalNote(note_markdown, [])
@@ -816,11 +817,11 @@ def write_export_searchable_db(searchable_data):
 
 def main():
   bib = parse_bib_file(f'{local_lean_root}docs/references.bib')
-  file_map, loc_map, notes, mod_docs, instances, tactic_docs = load_json()
-  setup_jinja_globals(file_map, loc_map, instances, bib)
+  file_map, loc_map, notes, mod_docs, instances, instances_for, tactic_docs = load_json()
+  setup_jinja_globals(file_map, loc_map, instances, instances_for, bib)
   write_import_gexf(file_map)
   write_decl_txt(loc_map)
-  write_html_files(file_map, loc_map, notes, mod_docs, instances, tactic_docs, bib)
+  write_html_files(file_map, loc_map, notes, mod_docs, instances, instances_for, tactic_docs, bib)
   write_redirects(loc_map, file_map)
   copy_css_and_js(html_root, use_symlinks=cl_args.l)
   copy_yaml_bib_files(html_root)

--- a/src/entrypoint.lean
+++ b/src/entrypoint.lean
@@ -1,7 +1,5 @@
 import all
 import .export_json
 
-
 open_all_locales
-
-run_cmd tactic.unsafe_run_io main
+-- note that `main` is executed by `lean --run`, which handles stderr vs stdout better

--- a/src/export_json.lean
+++ b/src/export_json.lean
@@ -340,10 +340,8 @@ do docs ← olean_doc_strings,
      (filename, json.array $ l.map write_module_doc_pair) :: rest
    end) [])
 
-#check @has_coe_to_sort.coe
-
 /--
-Three types of failure:
+The return type is to indicate three types of failure:
 * tactic failure (bug)
 * heuristic failure `exceptional.exception`
 * no name available `none`

--- a/src/export_json.lean
+++ b/src/export_json.lean
@@ -343,9 +343,9 @@ do docs ← olean_doc_strings,
 /-- Extract `[foo, bar]` from `has_pow foo bar`.
 
 The result is a map containing the type names as keys.  -/
-meta def find_instance_types (e : expr) : tactic (rb_map string unit) :=
+meta def find_instance_types (e : expr) : tactic (rb_set string) :=
 list.mfoldl (λ m e, do
-  e ← dunfold [`decidable_rel, `decidable_pred] e {fail_if_unchanged := ff},
+  -- e ← dunfold [`decidable_rel, `decidable_pred] e {fail_if_unchanged := ff},
   e ← whnf e transparency.reducible,
   t ← infer_type e,
   -- only look at arguments which are types or propositions
@@ -364,8 +364,8 @@ list.mfoldl (λ m e, do
   | expr.app _ _             := fail ("app, not a constant: " ++ to_string e)
   | expr.elet _ _ _ _        := fail ("elet, not a constant: " ++ to_string e)
   end | pure m,
-  pure (m.insert s ())
-) mk_rb_map e.get_app_args 
+  pure (m.insert s)
+) mk_rb_set e.get_app_args 
 
 meta def get_instances : tactic (rb_lmap string string × rb_lmap string string) :=
 attribute.get_instances `instance >>= list.mfoldl
@@ -377,7 +377,7 @@ attribute.get_instances `instance >>= list.mfoldl
         fail ("not a constant: " ++ to_string e),
       types ← find_instance_types e,
       let new_rev_map :=
-        types.fold rev_map (λ arg _ rev_map,  rev_map.insert arg inst_nm.to_string),
+        types.fold rev_map (λ arg rev_map, rev_map.insert arg inst_nm.to_string),
       return $ (map.insert class_nm.to_string inst_nm.to_string, new_rev_map))
   (mk_rb_map, mk_rb_map)
 

--- a/src/export_json.lean
+++ b/src/export_json.lean
@@ -344,8 +344,7 @@ do docs ← olean_doc_strings,
 
 The result is a map containing the type names as keys.  -/
 meta def find_instance_types (e : expr) : tactic (rb_set string) :=
-list.mfoldl (λ m e, do
-  -- e ← dunfold [`decidable_rel, `decidable_pred] e {fail_if_unchanged := ff},
+fold_explicit_args e mk_rb_set $ λ m e, do
   e ← whnf e transparency.reducible,
   t ← infer_type e,
   -- only look at arguments which are types or propositions
@@ -365,7 +364,6 @@ list.mfoldl (λ m e, do
   | expr.elet _ _ _ _        := fail ("elet, not a constant: " ++ to_string e)
   end | pure m,
   pure (m.insert s)
-) mk_rb_set e.get_app_args 
 
 meta def get_instances : tactic (rb_lmap string string × rb_lmap string string) :=
 attribute.get_instances `instance >>= list.mfoldl

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -54,6 +54,17 @@
     </details>
 {% endif %}
 
+{% if decl.name in instances_for %}
+    <details class="instances-for">
+        <summary>Available typeclasses</summary>
+        <ul>
+            {% for inst in instances_for[decl.name] %}
+                <li>{{ inst | linkify }}</li>
+            {% endfor %}
+        </ul>
+    </details>
+{% endif %}
+
 {% if decl.sorried %}
     <p class="sorry_msg"><strong>Note:</strong> this declaration is incomplete and uses <code>sorry</code>.</p>
 {% endif %}

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -56,7 +56,7 @@
 
 {% if decl.name in instances_for %}
     <details class="instances-for">
-        <summary>Available typeclasses</summary>
+        <summary>Available instances</summary>
         <ul>
             {% for inst in instances_for[decl.name] %}
                 <li>{{ inst | linkify }}</li>

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -69,6 +69,17 @@
     </details>
 {% endif %}
 
+{% if "↥" + decl.name in instances_for %}
+    <details class="instances-for">
+        <summary>Instances for <code>↥{{ decl.name | htmlify_name }}</code></summary>
+        <ul>
+            {% for inst in instances_for["↥" + decl.name] %}
+                <li>{{ inst | linkify }}</li>
+            {% endfor %}
+        </ul>
+    </details>
+{% endif %}
+
 {% if decl.sorried %}
     <p class="sorry_msg"><strong>Note:</strong> this declaration is incomplete and uses <code>sorry</code>.</p>
 {% endif %}

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -45,7 +45,7 @@
 
 {% if decl.name in instances %}
     <details class="instances">
-        <summary>Instances</summary>
+        <summary>Instances of this typeclass</summary>
         <ul>
             {% for inst in instances[decl.name] %}
                 <li>{{ inst | linkify }}</li>
@@ -56,7 +56,11 @@
 
 {% if decl.name in instances_for %}
     <details class="instances-for">
-        <summary>Available instances</summary>
+        {% if decl.name in instances %}
+            <summary>Instances of other typeclasses for <code>{{ decl.name | htmlify_name }}</code></summary>
+        {% else %}
+            <summary>Instances for <code>{{ decl.name | htmlify_name }}</code></summary>
+        {% endif %}
         <ul>
             {% for inst in instances_for[decl.name] %}
                 <li>{{ inst | linkify }}</li>

--- a/test/instances.lean
+++ b/test/instances.lean
@@ -1,8 +1,5 @@
-/-
-A short example to test the behavior of `get_instances`.
-To actually test this, paste this code above the `HACK` lines in `export_json.lean`, as after those
-lines notation becomes badly broken.
--/
+/- A short example to test the behavior of `get_instances`. -/
+import export_json
 
 class tc_explicit (x : Type*) (v : x).
 class tc_implicit {x : Type*} (v : x).

--- a/test/instances.lean
+++ b/test/instances.lean
@@ -12,9 +12,15 @@ instance foo.tc_implicit : tc_implicit (⟨1⟩ : foo) := ⟨⟩
 
 def foo.some_prop (b : foo) : Prop := true
 
+def some_set : set ℕ := {1}
+
+instance some_set.tc_implicit : tc_implicit ↥some_set := ⟨⟩
+
 instance : decidable_pred foo.some_prop := λ x, decidable.true
 
 #eval do
   (fwd, rev) ← get_instances,
   guard (rev.find "foo.some_prop" = ["foo.some_prop.decidable_pred"]),
-  guard (rev.find "foo" = ["foo.has_sizeof_inst", "foo.tc_explicit"])
+  guard (rev.find "foo" = ["foo.has_sizeof_inst", "foo.tc_explicit"]),
+  guard (rev.find "foo" = ["foo.has_sizeof_inst", "foo.tc_explicit"]),
+  guard (rev.find "↥some_set" = ["some_set.tc_implicit"])

--- a/test/instances.lean
+++ b/test/instances.lean
@@ -1,0 +1,23 @@
+/-
+A short example to test the behavior of `get_instances`.
+To actually test this, paste this code above the `HACK` lines in `export_json.lean`, as after those
+lines notation becomes badly broken.
+-/
+
+class tc_explicit (x : Type*) (v : x).
+class tc_implicit {x : Type*} (v : x).
+
+structure foo := (n : ℕ)
+
+instance foo.tc_explicit : tc_explicit foo ⟨1⟩ := ⟨⟩
+
+instance foo.tc_implicit : tc_implicit (⟨1⟩ : foo) := ⟨⟩
+
+def foo.some_prop (b : foo) : Prop := true
+
+instance : decidable_pred foo.some_prop := λ x, decidable.true
+
+#eval do
+  (fwd, rev) ← get_instances,
+  guard (rev.find "foo.some_prop" = ["foo.some_prop.decidable_pred"]),
+  guard (rev.find "foo" = ["foo.has_sizeof_inst", "foo.tc_explicit"])


### PR DESCRIPTION
I have no idea what I'm doing with this meta code, so it's entirely plausible there is a much better way to do this.

The heuristics for choosing what to display are overly generous, mainly because I don't know how to work with binders effectively in meta code.
Ideally instances about `list.lex` wouldn't show up under the list of instances for list, but that would need something that notices when type arguments to typeclasses are used as indices to later type arguments to typeclasses.

Either way, it seems to be collecting moderately helpful information.

We might want a special page that lists instances on pi, Type, Prop, and Sort; this PR collects the data for instances on those types, but doesn't attempt to render it anywhere

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/doc-gen.23163.20-.20reverse.20instance.20lookup/near/278550929)