### PR TITLE
display automatic translations to informal math

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "."
 version = "0.1"
-lean_version = "leanprover-community/lean:3.35.1"
+lean_version = "leanprover-community/lean:3.45.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "77ba0c4160793de8a824461128c57ca394792143"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "b2af6ee923fac9d60bd4e2fdce27b11287cc614f"}

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,4 +5,4 @@ lean_version = "leanprover-community/lean:3.45.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "b2af6ee923fac9d60bd4e2fdce27b11287cc614f"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "54c4c2220ab3b6a655e8d76c5c167a7d3d08dc9c"}

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,4 +5,4 @@ lean_version = "leanprover-community/lean:3.45.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "54c4c2220ab3b6a655e8d76c5c167a7d3d08dc9c"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "0bd4faeefa19bd012a18e5fe23bf46d3def25043"}

--- a/nav.js
+++ b/nav.js
@@ -259,6 +259,7 @@ async function fetchGood(...args) {
   }
 }
 
+/** Handler for clicking feedback buttons in informal statements. */
 window.addEventListener('load', _ => {
   for (const translationDiv of document.querySelectorAll('.translation_qs')) {
     const declName = translationDiv.getAttribute('data-decl')
@@ -299,4 +300,31 @@ window.addEventListener('load', _ => {
       }
     })
   }
+})
+
+const INFORMAL_OPEN_ID = 'informal_statement_open';
+function updateInformalOpen(state) {
+  if (state !== undefined) {
+    localStorage.setItem(INFORMAL_OPEN_ID, state);
+  } else {
+    state = localStorage.getItem(INFORMAL_OPEN_ID) ?? true;
+  }
+  const details = document.querySelectorAll('.informal_statement_details');
+  for (const detail of details) {
+    if (state) {
+      detail.setAttribute('open', '');
+    } else {
+      detail.removeAttribute('open');
+    }
+  }
+}
+
+window.addEventListener('load', _ => {
+  updateInformalOpen();
+  const checkbox = document.querySelector('#informal-open');
+  checkbox.checked = localStorage.getItem(INFORMAL_OPEN_ID) ?? true
+  checkbox.addEventListener('change', e => {
+    const value = checkbox.checked
+    updateInformalOpen(value)
+  })
 })

--- a/nav.js
+++ b/nav.js
@@ -304,14 +304,14 @@ window.addEventListener('load', _ => {
 
 const INFORMAL_OPEN_ID = 'informal_statement_open';
 function getInformalOpen() {
-  let x = localStorage.getItem(INFORMAL_OPEN_ID) ?? 'true'
-  return x === 'true' ? true : false
+  let x = localStorage.getItem(INFORMAL_OPEN_ID) ?? 'true';
+  return x === 'true';
 }
 function updateInformalOpen(state) {
   if (state !== undefined) {
     localStorage.setItem(INFORMAL_OPEN_ID, state);
   } else {
-    state = getInformalOpen()
+    state = getInformalOpen();
   }
   const details = document.querySelectorAll('.informal_statement_details');
   for (const detail of details) {

--- a/nav.js
+++ b/nav.js
@@ -274,9 +274,8 @@ window.addEventListener('load', _ => {
     feedbackForm.addEventListener('submit', async event => {
       event.preventDefault()
       try {
-        const name = event.submitter.getAttribute('name')
         const value = event.submitter.getAttribute('value')
-        url.searchParams.set(name, value)
+        url.searchParams.set('rate', value)
         feedbackForm.textContent = "Sending..."
         await fetchGood(url, { method: 'POST' });
         if (value === 'no') {
@@ -288,6 +287,7 @@ window.addEventListener('load', _ => {
               resolve(ta.value)
             })
           });
+          url.searchParams.delete('rate') // don't double-count the rating.
           url.searchParams.set('edit', edit)
           editForm.remove()
           feedbackForm.textContent = "Sending...";

--- a/nav.js
+++ b/nav.js
@@ -246,3 +246,30 @@ for (const elem of document.getElementsByClassName('gh_link')) {
     }
   }
 }
+
+// Informal Statement feedback form handler
+// -------
+
+window.addEventListener('load', event => {
+  const forms = document.querySelectorAll('form.informal_statement_form')
+  for (const form of forms) {
+    const url = new URL(form.getAttribute('action'))
+    form.addEventListener('submit', event => {
+      event.preventDefault()
+      const name = event.submitter.getAttribute('name')
+      const value = event.submitter.getAttribute('value')
+      url.searchParams.set(name, value)
+      form.textContent = "Sending..."
+      fetch(url, {method: 'POST'}).then(response => {
+        if (response.ok) {
+          form.textContent = "Thanks for your feedback!"
+          // [todo] in future we can get server to return stats on how many other people found this correct etc.
+        } else {
+          form.textContent = "There was a server error."
+        }
+      }).catch(err => {
+        form.textContent = `Error: ${err.message}`
+      })
+    })
+  }
+})

--- a/nav.js
+++ b/nav.js
@@ -305,11 +305,11 @@ window.addEventListener('load', _ => {
 const INFORMAL_OPEN_ID = 'informal_statement_open';
 
 function getInformalOpen() {
-  const item = localStorage.getItem(INFORMAL_OPEN_ID)
+  const item = localStorage.getItem(INFORMAL_OPEN_ID);
   if (!item) {
-    return false // default is closed
+    return false; // default is closed
   } else {
-    return JSON.parse(item)
+    return JSON.parse(item);
   }
 }
 

--- a/nav.js
+++ b/nav.js
@@ -307,7 +307,7 @@ const INFORMAL_OPEN_ID = 'informal_statement_open';
 function getInformalOpen() {
   const item = localStorage.getItem(INFORMAL_OPEN_ID)
   if (!item) {
-    return true // default is open
+    return false // default is closed
   } else {
     return JSON.parse(item)
   }

--- a/nav.js
+++ b/nav.js
@@ -303,11 +303,15 @@ window.addEventListener('load', _ => {
 })
 
 const INFORMAL_OPEN_ID = 'informal_statement_open';
+function getInformalOpen() {
+  let x = localStorage.getItem(INFORMAL_OPEN_ID) ?? 'true'
+  return x === 'true' ? true : false
+}
 function updateInformalOpen(state) {
   if (state !== undefined) {
     localStorage.setItem(INFORMAL_OPEN_ID, state);
   } else {
-    state = localStorage.getItem(INFORMAL_OPEN_ID) ?? true;
+    state = getInformalOpen()
   }
   const details = document.querySelectorAll('.informal_statement_details');
   for (const detail of details) {
@@ -322,7 +326,7 @@ function updateInformalOpen(state) {
 window.addEventListener('load', _ => {
   updateInformalOpen();
   const checkbox = document.querySelector('#informal-open');
-  checkbox.checked = localStorage.getItem(INFORMAL_OPEN_ID) ?? true
+  checkbox.checked = getInformalOpen()
   checkbox.addEventListener('change', e => {
     const value = checkbox.checked
     updateInformalOpen(value)

--- a/nav.js
+++ b/nav.js
@@ -296,39 +296,41 @@ window.addEventListener('load', _ => {
         }
         feedbackForm.textContent = "Thanks for your feedback!"
       } catch (err) {
-        feedbackForm.textContent = `Error: ${err.message}`
+        feedbackForm.textContent = `Error: ${err.message}`;
       }
     })
   }
 })
 
 const INFORMAL_OPEN_ID = 'informal_statement_open';
+
 function getInformalOpen() {
-  let x = localStorage.getItem(INFORMAL_OPEN_ID) ?? 'true';
-  return x === 'true';
+  const item = localStorage.getItem(INFORMAL_OPEN_ID)
+  if (!item) {
+    return true // default is open
+  } else {
+    return JSON.parse(item)
+  }
 }
+
 function updateInformalOpen(state) {
   if (state !== undefined) {
-    localStorage.setItem(INFORMAL_OPEN_ID, state);
+    localStorage.setItem(INFORMAL_OPEN_ID, JSON.stringify(state));
   } else {
     state = getInformalOpen();
   }
   const details = document.querySelectorAll('.informal_statement_details');
   for (const detail of details) {
-    if (state) {
-      detail.setAttribute('open', '');
-    } else {
-      detail.removeAttribute('open');
-    }
+    detail.open = state;
   }
 }
 
 window.addEventListener('load', _ => {
   updateInformalOpen();
   const checkbox = document.querySelector('#informal-open');
-  checkbox.checked = getInformalOpen()
+  checkbox.checked = getInformalOpen();
   checkbox.addEventListener('change', e => {
-    const value = checkbox.checked
-    updateInformalOpen(value)
-  })
+    const value = checkbox.checked;
+    updateInformalOpen(value);
+  });
 })

--- a/nav.js
+++ b/nav.js
@@ -262,35 +262,35 @@ async function fetchGood(...args) {
 /** Handler for clicking feedback buttons in informal statements. */
 window.addEventListener('load', _ => {
   for (const translationDiv of document.querySelectorAll('.translation_qs')) {
-    const declName = translationDiv.getAttribute('data-decl')
+    const declName = translationDiv.getAttribute('data-decl');
     if (!declName) {
-      console.error('no data-decl on translation_qs')
+      console.error('no data-decl on translation_qs');
     }
-    const feedbackForm = translationDiv.querySelector('.informal_statement_feedback')
-    const editForm = translationDiv.querySelector('.informal_statement_edit')
-    const ta = editForm.querySelector('textarea')
+    const feedbackForm = translationDiv.querySelector('.informal_statement_feedback');
+    const editForm = translationDiv.querySelector('.informal_statement_edit');
+    const ta = editForm.querySelector('textarea');
     const url = new URL(feedbackForm.getAttribute('action'));
-    url.searchParams.set('decl', declName)
-    url.searchParams.set('statement', ta.value)
+    url.searchParams.set('decl', declName);
+    url.searchParams.set('statement', ta.value);
     feedbackForm.addEventListener('submit', async event => {
-      event.preventDefault()
+      event.preventDefault();
       try {
-        const value = event.submitter.getAttribute('value')
-        url.searchParams.set('rate', value)
-        feedbackForm.textContent = "Sending..."
+        const value = event.submitter.getAttribute('value');
+        url.searchParams.set('rate', value);
+        feedbackForm.textContent = "Sending...";
         await fetchGood(url, { method: 'POST' });
         if (value === 'no') {
-          feedbackForm.textContent = "Thanks for your feedback! Optionally, please help us out by submitting a corrected statement: "
-          editForm.removeAttribute('style')
+          feedbackForm.textContent = "Thanks for your feedback! Optionally, please help us out by submitting a corrected statement: ";
+          editForm.removeAttribute('style');
           const edit = await new Promise((resolve, reject) => {
             editForm.addEventListener('submit', event => {
-              event.preventDefault()
-              resolve(ta.value)
-            })
+              event.preventDefault();
+              resolve(ta.value);
+            });
           });
-          url.searchParams.delete('rate') // don't double-count the rating.
-          url.searchParams.set('edit', edit)
-          editForm.remove()
+          url.searchParams.delete('rate'); // don't double-count the rating.
+          url.searchParams.set('edit', edit);
+          editForm.remove();
           feedbackForm.textContent = "Sending...";
           await fetchGood(url, { method: 'POST' });
         }
@@ -333,4 +333,4 @@ window.addEventListener('load', _ => {
     const value = checkbox.checked;
     updateInformalOpen(value);
   });
-})
+});

--- a/print_docs.py
+++ b/print_docs.py
@@ -25,6 +25,7 @@ from collections import Counter, defaultdict, namedtuple
 from pathlib import Path
 from typing import NamedTuple, List, Optional
 import sys
+import hashlib
 
 import mistletoe
 from mistletoe_renderer import CustomHTMLRenderer, PlaintextSummaryRenderer
@@ -321,6 +322,7 @@ def trace_deps(file_map):
   print(f"trace_deps: Processed {n_ok} / {n} dependency links")
   return graph
 
+
 def add_informal_statements_to_decls(informal, file_map):
   for file in file_map:
     for decl in file_map[file]:
@@ -330,6 +332,12 @@ def add_informal_statements_to_decls(informal, file_map):
         if informal_decl is not None and decl['args'] == informal_decl['args'] and decl['type'] == informal_decl['type']:
           informal_statement = informal_decl['informal_statement']
       decl['informal_statement'] = informal_statement
+      # create a hash of the given informal statement string
+      # there is no need for it to be a cryptographic hash, better to use xxhash but requires dependency
+      # we can't use builtin `hash` because not stable across executions.
+      m = hashlib.md5()
+      m.update(informal_statement.encode())
+      decl['informal_statement_digest'] = m.hexdigest()
 
 def load_json():
   try:

--- a/print_docs.py
+++ b/print_docs.py
@@ -331,6 +331,8 @@ def add_informal_statements_to_decls(informal, file_map):
         informal_decl = informal.get(decl['name'], None)
         if informal_decl is not None and decl['args'] == informal_decl['args'] and decl['type'] == informal_decl['type']:
           informal_statement = informal_decl['informal_statement']
+      # a hack to avoid `$a<b$`` being interpreted as html
+      informal_statement = informal_statement.replace('<', '< ')
       decl['informal_statement'] = informal_statement
       # create a hash of the given informal statement string
       # there is no need for it to be a cryptographic hash, better to use xxhash but requires dependency

--- a/print_docs.py
+++ b/print_docs.py
@@ -321,6 +321,16 @@ def trace_deps(file_map):
   print(f"trace_deps: Processed {n_ok} / {n} dependency links")
   return graph
 
+def add_informal_statements_to_decls(informal, file_map):
+  for file in file_map:
+    for decl in file_map[file]:
+      informal_statement = ""
+      if decl['kind'] == 'theorem':
+        informal_decl = informal.get(decl['name'], None)
+        if informal_decl is not None and decl['args'] == informal_decl['args'] and decl['type'] == informal_decl['type']:
+          informal_statement = informal_decl['informal_statement']
+      decl['informal_statement'] = informal_statement
+
 def load_json():
   try:
     with open('export.json', 'r', encoding='utf-8') as f:
@@ -333,6 +343,9 @@ def load_json():
       print(raw)
     raise
   file_map, loc_map = separate_results(decls['decls'])
+  with gzip.open('tagged_nl2.json.gz') as tagged_nl:
+    translations = json.load(tagged_nl)
+  add_informal_statements_to_decls(translations, file_map)
   for entry in decls['tactic_docs']:
     if len(entry['tags']) == 0:
       entry['tags'] = ['untagged']

--- a/style.css
+++ b/style.css
@@ -710,4 +710,19 @@ a:hover {
 .informal_statement .translation_qs {
     color:gray;
 }
-  
+
+.informal_statement form {
+  display: inline;
+}
+
+.informal_statement form button {
+    background: none!important;
+    border: none;
+    padding: 0!important;
+    /*optional*/
+    font-family: arial, sans-serif;
+    /*input has OS specific font-family*/
+    color: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+}

--- a/style.css
+++ b/style.css
@@ -719,10 +719,6 @@ a:hover {
     background: none!important;
     border: none;
     padding: 0!important;
-    /*optional*/
-    font-family: arial, sans-serif;
-    /*input has OS specific font-family*/
     color: inherit;
-    text-decoration: underline;
     cursor: pointer;
 }

--- a/style.css
+++ b/style.css
@@ -697,3 +697,39 @@ a:hover {
     margin-top: 2em;
     margin-bottom: 2em;
 }
+
+.informal_statement {
+    margin-top: 1em;
+}
+
+.informal_statement .explain {
+    color:var(--link-color);
+}
+
+.informal_statement .explain .tooltiptext {
+    visibility: hidden;
+    width: 120px;
+    background-color: black;
+    color: #fff;
+    text-align: center;
+    padding: 5px 0;
+    border-radius: 6px;   
+    
+    /* Position the tooltip text - see examples below! */
+    top: -5px;
+    left: 105%;
+
+}
+
+.informal_statement .statement, .informal_statement .translation_qs {
+    margin-left: 2ch;
+}
+
+.informal_statement .translation_qs {
+    color:gray;
+}
+  
+/* Show the tooltip text when you mouse over the tooltip container */
+.informal_statement .explain:hover .tooltiptext {
+    visibility: visible;
+}

--- a/style.css
+++ b/style.css
@@ -711,11 +711,11 @@ a:hover {
     color:gray;
 }
 
-.informal_statement form {
+.informal_statement_feedback {
   display: inline;
 }
 
-.informal_statement form button {
+.informal_statement_feedback button {
     background: none!important;
     border: none;
     padding: 0!important;
@@ -725,6 +725,11 @@ a:hover {
     cursor: pointer;
 }
 
-.informal_statement form button:hover {
+.informal_statement_feedback button:hover {
   text-decoration: underline
+}
+
+.informal_statement_edit textarea {
+    font-size: 1rem;
+    width: 100%;
 }

--- a/style.css
+++ b/style.css
@@ -702,24 +702,6 @@ a:hover {
     margin-top: 1em;
 }
 
-.informal_statement .explain {
-    color:var(--link-color);
-}
-
-.informal_statement .explain .tooltiptext {
-    visibility: hidden;
-    width: 120px;
-    background-color: black;
-    color: #fff;
-    text-align: center;
-    padding: 5px 0;
-    border-radius: 6px;   
-    
-    /* Position the tooltip text - see examples below! */
-    top: -5px;
-    left: 105%;
-
-}
 
 .informal_statement .statement, .informal_statement .translation_qs {
     margin-left: 2ch;
@@ -729,7 +711,3 @@ a:hover {
     color:gray;
 }
   
-/* Show the tooltip text when you mouse over the tooltip container */
-.informal_statement .explain:hover .tooltiptext {
-    visibility: visible;
-}

--- a/style.css
+++ b/style.css
@@ -377,11 +377,16 @@ nav {
     font-size: inherit;
 }
 
-#color-theme-switcher {
+#settings form {
     display: flex;
     justify-content: space-between;
     padding: 0 2ex;
     flex-flow: row wrap;
+}
+
+#settings input[type="checkbox"] {
+    margin-left: 5px;
+    margin-top: 5px;
 }
 
 /* custom radio buttons for dark/light switch */

--- a/style.css
+++ b/style.css
@@ -719,6 +719,12 @@ a:hover {
     background: none!important;
     border: none;
     padding: 0!important;
-    color: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    color: var(--link-color);
     cursor: pointer;
+}
+
+.informal_statement form button:hover {
+  text-decoration: underline
 }

--- a/templates/base.j2
+++ b/templates/base.j2
@@ -71,6 +71,7 @@ MathJax = {
         ignoreHtmlClass: 'tex2jax_ignore',
         processHtmlClass: 'tex2jax_process',
     },
+    loader: {load: ['ui/lazy']}
 };
 
 siteRoot = "{{ site_root }}";

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -41,17 +41,19 @@
         <div class="statement">
             {{ decl.informal_statement | convert_markdown }}
         </div>
-        
+
         <div class="translation_qs">
             This translation to informal mathematics is automatically generated and should NOT be trusted!
             The translation is a <a href="">beta feature powered by OpenAI's Codex API</a>.
             <br>
-            Does this translation look correct? <a href="">Yes</a> | <a href = "">No</a> 
+            Does this translation look correct?
+            <form action="https://lean-chat.deno.dev/doc-gen?digest={{decl.informal_statement_digest}}" method="post">
+              <button type="submit" name="rate" value="yes">Yes</button>
+              <button type="submit" name="rate" value="no">No</button>
+            </form>
         </div>
     </div>
-
-
-</details> 
+</details>
 
 {% endif %}
 

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -34,7 +34,7 @@
 
 {% if decl.informal_statement %}
 
-<details open class="informal_statement_details">
+<details class="informal_statement_details">
     <summary>Informal translation</summary>
 
     <div class="informal_statement">

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -46,8 +46,8 @@
             This translation to informal mathematics is automatically generated and should NOT be trusted!
             The translation is a <a href="">beta feature powered by OpenAI's Codex API</a>.
             <br>
-            Does this translation look correct?
-            <form action="https://lean-chat.deno.dev/doc-gen?digest={{decl.informal_statement_digest}}" method="post">
+            <form class="informal_statement_form" action="https://lean-chat-server.deno.dev/doc-gen?digest={{decl.informal_statement_digest}}" method="post">
+              <span>Does this translation look correct?</span>
               <button type="submit" name="rate" value="yes">Yes</button>
               <button type="submit" name="rate" value="no">No</button>
             </form>

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -34,7 +34,7 @@
 
 {% if decl.informal_statement %}
 
-<details open>
+<details open class="informal_statement_details">
     <summary>Informal translation</summary>
 
     <div class="informal_statement">

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -42,14 +42,18 @@
             {{ decl.informal_statement | convert_markdown }}
         </div>
 
-        <div class="translation_qs">
+        <div class="translation_qs" data-decl="{{decl.name}}">
             This translation to informal mathematics is automatically generated and should NOT be trusted!
             The translation is a <a href="">beta feature powered by OpenAI's Codex API</a>.
             <br>
-            <form class="informal_statement_form" action="https://lean-chat-server.deno.dev/doc-gen?digest={{decl.informal_statement_digest}}" method="post">
-              <span>Does this translation look correct?</span>
+            <form class="informal_statement_feedback" action="https://lean-chat-server.deno.dev/doc-gen?digest={{decl.informal_statement_digest}}" method="post">
+              <span class="status" >Does this translation look correct?</span>
               <button type="submit" name="rate" value="yes">Yes</button>
               <button type="submit" name="rate" value="no">No</button>
+            </form>
+            <form class="informal_statement_edit" style="display: none;" action="#">
+                <textarea name="statement" rows="6">{{decl.informal_statement}}</textarea>
+                <button type="submit">Submit</button>
             </form>
         </div>
     </div>

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -39,7 +39,7 @@
 
     <div class="informal_statement">
         <div class="statement">
-            {{ decl.informal_statement }}
+            {{ decl.informal_statement | convert_markdown }}
         </div>
         
         <div class="translation_qs">

--- a/templates/decl.j2
+++ b/templates/decl.j2
@@ -32,6 +32,29 @@
 
 {{ decl.doc_string | convert_markdown }}
 
+{% if decl.informal_statement %}
+
+<details open>
+    <summary>Informal translation</summary>
+
+    <div class="informal_statement">
+        <div class="statement">
+            {{ decl.informal_statement }}
+        </div>
+        
+        <div class="translation_qs">
+            This translation to informal mathematics is automatically generated and should NOT be trusted!
+            The translation is a <a href="">beta feature powered by OpenAI's Codex API</a>.
+            <br>
+            Does this translation look correct? <a href="">Yes</a> | <a href = "">No</a> 
+        </div>
+    </div>
+
+
+</details> 
+
+{% endif %}
+
 {% if decl.equations | length %}
     <details>
         <summary>Equations</summary>

--- a/templates/navbar.j2
+++ b/templates/navbar.j2
@@ -46,4 +46,11 @@
         <input type="radio" name="color_theme" id="color-theme-light" value="light" autocomplete="off">light</label>
 </form>
 
+<form>
+  <label for="informal-open">
+    <input type="checkbox" id="informal-open" checked>
+    expand informal translations
+  </label>
+</form>
+
 </div>

--- a/templates/navbar.j2
+++ b/templates/navbar.j2
@@ -48,7 +48,7 @@
 
 <form>
   <label for="informal-open">
-    <input type="checkbox" id="informal-open" checked>
+    <input type="checkbox" id="informal-open">
     expand informal translations
   </label>
 </form>

--- a/templates/navbar.j2
+++ b/templates/navbar.j2
@@ -36,7 +36,7 @@
 
 <div id="settings">
 
-<h3>Color scheme</h3>
+<h3>Settings</h3>
 <form id="color-theme-switcher">
     <label for="color-theme-dark">
         <input type="radio" name="color_theme" id="color-theme-dark" value="dark" autocomplete="off">dark</label>


### PR DESCRIPTION
Thanks to work by @zhangir-azerbayev , we have a dataset of every declaration in (a recent version of) mathlib translated to natural language. People from OpenAI are interested in improving this; in principle we can regenerate these translations periodically, and update the model with user responses from the displayed translations. 

There is a static json file containing the translations. It also stores the theorem name and statement that were used to generate the text. doc-gen checks that the statement hasn't changed before printing the translation, so even if we go months between updates, the worst we'll see is a lot of theorems with no translation.

All of this is WIP:
* We need a doc page on the community website explaining what's going on here.
* I did not try hard at all on the display stylilng. Obviously this needs to be improved. Right now I put it in a `<details>` menu, expanded by default to make browsing this demo easier. I think they should be collapsed by default in production, at least until the translations improve.
* The response buttons don't go anywhere. We should have them pop up a window that allows the user, optionally, to correct the statement and submit. They can target a Google form or any other database.