### PR TITLE
Include the archive and counterexamples directories

### DIFF
--- a/gen_docs
+++ b/gen_docs
@@ -43,8 +43,8 @@ echo "import archive_all" >> "$source/all.lean"
 
 # ensure the archive is on the lean path
 leanpkg configure
-echo "path ./archive" >> leanpkg.path
-echo "path ./counterexamples" >> leanpkg.path
+echo "path $source/archive" >> leanpkg.path
+echo "path $source/counterexamples" >> leanpkg.path
 lean --path
 lean --run src/entrypoint.lean >export.json
 

--- a/gen_docs
+++ b/gen_docs
@@ -36,13 +36,14 @@ fi
 (cd "$source" && leanproject mk-all)
 (cd "$source/archive" && leanproject mk-all && mv all.lean archive_all.lean)
 (cd "$source/counterexamples" && leanproject mk-all && mv all.lean counterexamples_all.lean)
-echo "import counterexamples_all" >> all.lean
-echo "import archive_all" >> all.lean
+echo "import counterexamples_all" >> "$source/all.lean"
+echo "import archive_all" >> "$source/all.lean"
 
 # ensure the archive is on the lean path
 leanpkg configure
 echo "path ./archive" >> leanpkg.path
 echo "path ./counterexamples" >> leanpkg.path
+lean --path
 lean --run src/entrypoint.lean >export.json
 
 python3 print_docs.py -r "$source" -w "$site_root" "${args[@]}"

--- a/gen_docs
+++ b/gen_docs
@@ -40,7 +40,7 @@ echo "import counterexamples_all" >> "$source/all.lean"
 echo "import archive_all" >> "$source/all.lean"
 
 echo "# counterexamples_all.lean contains"
-cat $source/counterexample/counterexamples_all.lean
+cat $source/counterexamples/counterexamples_all.lean
 
 # ensure the archive is on the lean path
 echo "path $source/archive" >> leanpkg.path

--- a/gen_docs
+++ b/gen_docs
@@ -42,11 +42,8 @@ echo "import counterexamples_all" >> "$source/all.lean"
 echo "import archive_all" >> "$source/all.lean"
 
 # ensure the archive is on the lean path
-lean --path
-leanpkg configure
 echo "path $source/archive" >> leanpkg.path
 echo "path $source/counterexamples" >> leanpkg.path
-lean --path
 lean --run src/entrypoint.lean >export.json
 
 python3 print_docs.py -r "$source" -w "$site_root" "${args[@]}"

--- a/gen_docs
+++ b/gen_docs
@@ -32,8 +32,17 @@ if [ "$link" -eq "1" ]; then
   args+=('-l')
 fi
 
-bash "$source"scripts/mk_all.sh
+# build the file lists for mathlib and the archives
+(cd "$source" && leanproject mk-all)
+(cd "$source/archive" && leanproject mk-all && mv all.lean archive_all.lean)
+(cd "$source/counterexamples" && leanproject mk-all && mv all.lean counterexamples_all.lean)
+echo "import counterexamples_all" >> all.lean
+echo "import archive_all" >> all.lean
+
+# ensure the archive is on the lean path
+leanpkg configure
+echo "path ./archive" >> leanpkg.path
+echo "path ./counterexamples" >> leanpkg.path
 lean --run src/entrypoint.lean >export.json
-bash "$source"scripts/rm_all.sh
 
 python3 print_docs.py -r "$source" -w "$site_root" "${args[@]}"

--- a/gen_docs
+++ b/gen_docs
@@ -39,6 +39,9 @@ fi
 echo "import counterexamples_all" >> "$source/all.lean"
 echo "import archive_all" >> "$source/all.lean"
 
+echo "# counterexamples_all.lean contains"
+cat $source/counterexample/counterexamples_all.lean
+
 # ensure the archive is on the lean path
 echo "path $source/archive" >> leanpkg.path
 echo "path $source/counterexamples" >> leanpkg.path

--- a/gen_docs
+++ b/gen_docs
@@ -32,6 +32,8 @@ if [ "$link" -eq "1" ]; then
   args+=('-l')
 fi
 
+(cd "$source" && git checkout eric-wieser/archive-counterexample-tomls)
+
 # build the file lists for mathlib and the archives
 (cd "$source" && leanproject mk-all)
 (cd "$source/archive" && leanproject mk-all && mv all.lean archive_all.lean)

--- a/gen_docs
+++ b/gen_docs
@@ -32,8 +32,6 @@ if [ "$link" -eq "1" ]; then
   args+=('-l')
 fi
 
-(cd "$source" && git checkout eric-wieser/archive-counterexample-tomls)
-
 # build the file lists for mathlib and the archives
 (cd "$source" && leanproject mk-all)
 (cd "$source/archive" && leanproject mk-all && mv all.lean archive_all.lean)

--- a/gen_docs
+++ b/gen_docs
@@ -42,6 +42,7 @@ echo "import counterexamples_all" >> "$source/all.lean"
 echo "import archive_all" >> "$source/all.lean"
 
 # ensure the archive is on the lean path
+lean --path
 leanpkg configure
 echo "path $source/archive" >> leanpkg.path
 echo "path $source/counterexamples" >> leanpkg.path

--- a/gen_docs
+++ b/gen_docs
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 link=0
 site_root='/'
 while [ "$1" != "" ]; do
@@ -36,11 +37,8 @@ fi
 (cd "$source" && leanproject mk-all)
 (cd "$source/archive" && leanproject mk-all && mv all.lean archive_all.lean)
 (cd "$source/counterexamples" && leanproject mk-all && mv all.lean counterexamples_all.lean)
-echo "import counterexamples_all" >> "$source/all.lean"
-echo "import archive_all" >> "$source/all.lean"
-
-echo "# counterexamples_all.lean contains"
-cat $source/counterexamples/counterexamples_all.lean
+echo "import counterexamples_all" >> "$source/src/all.lean"
+echo "import archive_all" >> "$source/src/all.lean"
 
 # ensure the archive is on the lean path
 echo "path $source/archive" >> leanpkg.path

--- a/nav.js
+++ b/nav.js
@@ -188,9 +188,11 @@ searchInput.addEventListener('input', async (ev) => {
 
   const oldSR = document.getElementById('search_results');
   const sr = oldSR.cloneNode(false);
-  for (const {decl} of result) {
+  for (const {decl, proj} of result) {
     const d = sr.appendChild(document.createElement('a'));
-    d.innerText = decl;
+    const note = document.createElement("span");
+    note.innerText = proj;
+    d.append(decl, note);
     d.title = decl;
     d.href = `${siteRoot}find/${decl}`;
   }

--- a/nav.js
+++ b/nav.js
@@ -221,11 +221,13 @@ if (howabout) {
   declSearch(query).then((results) => {
       howabout.innerText = 'How about one of these instead:';
       const ul = howabout.appendChild(document.createElement('ul'));
-      for (const {decl} of results) {
+      for (const {decl, proj} of results) {
           const li = ul.appendChild(document.createElement('li'));
           const a = li.appendChild(document.createElement('a'));
           a.href = `${siteRoot}find/${decl}`;
           a.appendChild(document.createElement('code')).innerText = decl;
+          li.append(" ");
+          li.appendChild(document.createElement('small')).innerText = "(" + proj + ")";
       }
   });
 }

--- a/print_docs.py
+++ b/print_docs.py
@@ -170,8 +170,8 @@ def get_name_from_leanpkg_path(p: Path) -> str:
   if p.parts[-3:] == Path('bin/../library').parts:
     return "core"
 
-  # try the toml
-  p_leanpkg = p / '..' / 'leanpkg.toml'
+  # try the toml (no src folder)
+  p_leanpkg = p / 'leanpkg.toml'
   try:
     f = p_leanpkg.open()
   except FileNotFoundError:
@@ -181,8 +181,8 @@ def get_name_from_leanpkg_path(p: Path) -> str:
       parsed_toml = toml.loads(f.read())
     return parsed_toml['package']['name']
 
-  # try the toml (no src folder)
-  p_leanpkg = p / 'leanpkg.toml'
+  # try the toml
+  p_leanpkg = p / '..' / 'leanpkg.toml'
   try:
     f = p_leanpkg.open()
   except FileNotFoundError:

--- a/print_docs.py
+++ b/print_docs.py
@@ -150,6 +150,14 @@ mathlib_github_src_root_with_commit = f"{mathlib_github_root}/blob/{mathlib_comm
 mathlib_github_src_root = f"{mathlib_github_root}/blob/master/src/"
 url_rewrites.append([mathlib_github_src_root, mathlib_github_src_root_with_commit])
 
+mathlib_github_archive_root_with_commit = f"{mathlib_github_root}/blob/{mathlib_commit}/archive/"
+mathlib_github_archive_root = f"{mathlib_github_root}/blob/master/archive/"
+url_rewrites.append([mathlib_github_archive_root, mathlib_github_archive_root_with_commit])
+
+mathlib_github_counterexamples_root_with_commit = f"{mathlib_github_root}/blob/{mathlib_commit}/counterexamples/"
+mathlib_github_counterexamples_root = f"{mathlib_github_root}/blob/master/counterexamples/"
+url_rewrites.append([mathlib_github_counterexamples_root, mathlib_github_counterexamples_root_with_commit])
+
 # The Lean version changes infrequently enough that we don't need to rewrite it
 lean_commit = subprocess.check_output(['lean', '--run', 'src/lean_commit.lean']).decode()
 lean_root = f'https://github.com/leanprover-community/lean/blob/{lean_commit}/library/'
@@ -164,6 +172,17 @@ def get_name_from_leanpkg_path(p: Path) -> str:
 
   # try the toml
   p_leanpkg = p / '..' / 'leanpkg.toml'
+  try:
+    f = p_leanpkg.open()
+  except FileNotFoundError:
+    pass
+  else:
+    with f:
+      parsed_toml = toml.loads(f.read())
+    return parsed_toml['package']['name']
+
+  # try the toml (no src folder)
+  p_leanpkg = p / 'leanpkg.toml'
   try:
     f = p_leanpkg.open()
   except FileNotFoundError:
@@ -229,12 +248,16 @@ def convert_markdown(ds):
 library_link_roots = {
   'core': lean_root,
   'mathlib': mathlib_github_src_root,
+  'mathlib-archive': mathlib_github_archive_root,
+  'mathlib-counterexamples': mathlib_github_counterexamples_root,
 }
 
 # TODO: allow extending this for third-party projects
 canonical_roots = {
   'core': 'https://leanprover-community.github.io/mathlib_docs',
   'mathlib': 'https://leanprover-community.github.io/mathlib_docs',
+  'mathlib-archive': 'https://leanprover-community.github.io/mathlib_docs',
+  'mathlib-counterexamples': 'https://leanprover-community.github.io/mathlib_docs',
 }
 
 def get_canonical_url(path, project='mathlib'):

--- a/print_docs.py
+++ b/print_docs.py
@@ -788,11 +788,12 @@ def write_export_db(export_db):
   with gzip.GzipFile(html_root + 'export_db.json.gz', 'w') as zout:
     zout.write(json_str.encode('utf-8'))
 
-def mk_export_searchable_map_entry(filename_name, name, description, kind = '', attributes = []):
+def mk_export_searchable_map_entry(proj, filename_name, name, description, kind = '', attributes = []):
   return {
     # 'module': filename_name,
     'name': name,
     'description': description,
+    'p': proj,
     # 'kind': kind,
     # 'attributes': attributes,
   }
@@ -803,13 +804,13 @@ def mk_export_searchable_db(file_map, tactic_docs):
   for fn, decls in file_map.items():
     filename_name = str(fn.url)
     for obj in decls:
-      decl_entry = mk_export_searchable_map_entry(filename_name, obj['name'], obj['doc_string'], obj['kind'], obj['attributes'])
+      decl_entry = mk_export_searchable_map_entry(fn.project, filename_name, obj['name'], obj['doc_string'], obj['kind'], obj['attributes'])
       export_searchable_db.append(decl_entry)
       for (cstr_name, _) in obj['constructors']:
-        cstr_entry = mk_export_searchable_map_entry(filename_name, cstr_name, obj['doc_string'], obj['kind'], obj['attributes'])
+        cstr_entry = mk_export_searchable_map_entry(fn.project, filename_name, cstr_name, obj['doc_string'], obj['kind'], obj['attributes'])
         export_searchable_db.append(cstr_entry)
       for (sf_name, _) in obj['structure_fields']:
-        sf_entry = mk_export_searchable_map_entry(filename_name, sf_name, obj['doc_string'], obj['kind'], obj['attributes'])
+        sf_entry = mk_export_searchable_map_entry(fn.project, filename_name, sf_name, obj['doc_string'], obj['kind'], obj['attributes'])
         export_searchable_db.append(sf_entry)
 
   # for tactic in tactic_docs:

--- a/search.js
+++ b/search.js
@@ -23,14 +23,14 @@ function matchCaseSensitive(declName, lowerDeclName, pat) {
 }
 
 function loadDecls(searchableDataCnt) {
-    return searchableDataCnt.map(({name, description}) => [name, name.toLowerCase(), description.toLowerCase()])
+    return searchableDataCnt.map(({p, name, description}) => [name, name.toLowerCase(), description.toLowerCase(), p])
 }
 
 function getMatches(decls, pat, maxResults = 30) {
     const lowerPats = pat.toLowerCase().split(/\s/g);
     const patNoSpaces = pat.replace(/\s/g, '');
     const results = [];
-    for (const [decl, lowerDecl, lowerDoc] of decls) {
+    for (const [decl, lowerDecl, lowerDoc, proj] of decls) {
         let err = matchCaseSensitive(decl, lowerDecl, patNoSpaces);
 
         // match all words as substrings of docstring
@@ -39,7 +39,7 @@ function getMatches(decls, pat, maxResults = 30) {
         }
 
         if (err !== undefined) {
-            results.push({decl, err});
+            results.push({decl, err, proj});
         }
     }
     return results.sort(({err: a}, {err: b}) => a - b).slice(0, maxResults);

--- a/style.css
+++ b/style.css
@@ -277,6 +277,7 @@ header header_filename {
 #search_results a > span {
     opacity: 0.5;
     font-size: 75%;
+    float: right;
 }
 
 #search_results .selected {

--- a/style.css
+++ b/style.css
@@ -274,6 +274,11 @@ header header_filename {
     padding-left: 0.5ex;
     cursor: pointer;
 }
+#search_results a > span {
+    opacity: 0.5;
+    font-size: 75%;
+}
+
 #search_results .selected {
     background: white;
     border-color: #f0a202;


### PR DESCRIPTION
This takes advantage of the new toml files in https://github.com/leanprover-community/mathlib/pull/18388.

Fixes #147.

This also adjusts the search box and find page to show the project name next to the result.
There is some styling discussion on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/docs.20archive/near/326367916), but there seems to be no strong preference between the first option (implemented in this PR) and the third one in that thread.