### PR TITLE
feat: link to the mapped page in the deprecation banner

### DIFF
--- a/print_docs.py
+++ b/print_docs.py
@@ -252,20 +252,11 @@ library_link_roots = {
   'mathlib-counterexamples': mathlib_github_counterexamples_root,
 }
 
-# TODO: allow extending this for third-party projects
-canonical_roots = {
-  'core': 'https://leanprover-community.github.io/mathlib_docs',
-  'mathlib': 'https://leanprover-community.github.io/mathlib_docs',
-  'mathlib-archive': 'https://leanprover-community.github.io/mathlib_docs',
-  'mathlib-counterexamples': 'https://leanprover-community.github.io/mathlib_docs',
-}
-
 # mathlib3 is deprecated. For each mathlib3 module we know the mathlib4
 # successor of, declare it as the canonical URL so search engines transfer
 # ranking to the maintained library. Modules without a mapping fall back
-# to the existing self-canonical behavior — we explicitly avoid pointing
-# every page at the mathlib4 docs root, which is the many-to-one canonical
-# anti-pattern Google rejects.
+# to point at the mathlib4 docs root. These canonical URLs should boost
+# the ranking of the new docs in search engines.
 MATHLIB4_DOCS_ROOT = 'https://leanprover-community.github.io/mathlib4_docs/'
 import yaml as _yaml
 try:
@@ -279,11 +270,7 @@ def get_canonical_url(path, project='mathlib'):
     target = _mathlib4_map.get(path[:-5].replace('/', '.'))
     if target:
       return MATHLIB4_DOCS_ROOT + target + '.html'
-  try:
-    root = canonical_roots[project]
-  except KeyError:
-    return None
-  return root + '/' + path
+  return MATHLIB4_DOCS_ROOT
 
 def library_link(filename: ImportName, line=None):
   try:
@@ -619,7 +606,7 @@ def write_html_files(partition, loc_map, notes, mod_docs, instances, instances_f
     current_filename = '404.html'
     current_project = None
     out.write(env.get_template('404.j2').render(
-      canonical_url = None,
+      canonical_url = MATHLIB4_DOCS_ROOT,
       active_path=''))
 
   kinds = [('tactic', 'tactics'), ('command', 'commands'), ('hole_command', 'hole_commands'), ('attribute', 'attributes')]

--- a/templates/base.j2
+++ b/templates/base.j2
@@ -9,9 +9,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{% block metadesc %}The Lean 3 mathematical library, mathlib, is a community-driven effort to build a unified library of mathematics formalized in the Lean proof assistant.{% endblock %}" />
-    {% if canonical_url is not none %}
     <link rel="canonical" href="{{ canonical_url }}" />
-    {% endif %}
     <meta property="og:title" content="{{ self.title() }} - mathlib3 docs">
     <meta property="og:site_name" content="mathlib for Lean 3 - API documentation">
     <meta property="og:description" content="{{ self.metadesc() }}">
@@ -24,7 +22,7 @@
 
 <aside class="deprecated_banner" role="alert">
     <strong>mathlib3 is no longer maintained</strong> &mdash; see the
-    <a href="https://leanprover-community.github.io/mathlib4_docs/">mathlib4 docs</a>
+    <a href="{{ canonical_url }}">mathlib4 docs</a>
     for the current library.
 </aside>
 


### PR DESCRIPTION
- Change the link in the deprecation banner to point to the mapped (mathlib4) page when available
- Change the canonical URL of all the pages which aren't mapped to the mathlib4 docs root

[#mathlib4 > De-emphasizing mathlib3 docs in search results via canonical](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/De-emphasizing.20mathlib3.20docs.20in.20search.20results.20via.20canonical/with/593178273)

Google's [best practices](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#best-practices) for canoncal URLs don't seem to advise against many-to-one (just against one-to-many), though I'm not an SEO expert so I'm not sure what's best.